### PR TITLE
ci: run full verification and screenshot checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Unit tests
-        run: pnpm test
+      - name: Unit tests with coverage
+        run: pnpm test:coverage
 
       - name: Build
         run: pnpm build
@@ -55,28 +55,25 @@ jobs:
       - name: E2E tests
         run: pnpm test:e2e
 
-      - name: Resolve diff range
-        id: diff_range
+      - name: Resolve app page files
+        id: app_pages
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
-            echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "base_sha=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
-            echo "head_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          fi
+          APP_PAGE_FILES="$(git ls-files src/app | grep '/page.tsx$' || true)"
+          {
+            echo "files<<EOF"
+            echo "$APP_PAGE_FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Detect feature routes
-        id: feature_routes
+      - name: Resolve screenshot routes
+        id: screenshot_routes
         env:
-          CI_BASE_SHA: ${{ steps.diff_range.outputs.base_sha }}
-          CI_HEAD_SHA: ${{ steps.diff_range.outputs.head_sha }}
+          CHANGED_FILES: ${{ steps.app_pages.outputs.files }}
         run: pnpm run ci:feature-routes
 
       - name: Capture feature screenshots
-        if: steps.feature_routes.outputs.has_routes == 'true'
         env:
-          SCREENSHOT_ROUTES_JSON: ${{ steps.feature_routes.outputs.routes_json }}
+          SCREENSHOT_ROUTES_JSON: ${{ steps.screenshot_routes.outputs.routes_json }}
         run: pnpm run test:e2e:screenshots
 
       - name: Upload feature screenshots

--- a/scripts/ci/ci-workflow.test.mjs
+++ b/scripts/ci/ci-workflow.test.mjs
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const workflowPath = path.resolve(process.cwd(), ".github/workflows/ci.yml");
+
+function readWorkflow() {
+  return fs.readFileSync(workflowPath, "utf8");
+}
+
+describe("ci workflow", () => {
+  it("runs the full verification gate", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("run: pnpm lint");
+    expect(workflow).toContain("run: pnpm typecheck");
+    expect(workflow).toContain("run: pnpm test:coverage");
+    expect(workflow).toContain("run: pnpm build");
+    expect(workflow).toContain("run: pnpm test:e2e");
+    expect(workflow).toContain("run: pnpm run test:e2e:screenshots");
+    expect(workflow).not.toContain("if: steps.feature_routes.outputs.has_routes == 'true'");
+    expect(workflow).not.toContain("name: Resolve diff range");
+    expect(workflow).not.toContain("name: Detect feature routes");
+  });
+
+  it("always uploads CI artifacts for debugging", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("name: Upload feature screenshots");
+    expect(workflow).toContain("name: Upload Playwright artifacts");
+    expect(workflow).toContain("if: always()");
+  });
+});


### PR DESCRIPTION
This PR hardens CI to run the complete verification suite on every run.
It switches unit tests to coverage mode and removes diff-based screenshot gating by deriving routes from all app page files before running the screenshot suite.
It also adds a Vitest guard test in scripts/ci/ci-workflow.test.mjs that enforces required CI commands, confirms screenshot checks are not conditionally skipped, and ensures artifact uploads remain on always().
