### PR TITLE
feat: dynamic SEO metadata and OG images

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Configure these in `.env.local`:
   - optional Arcade project id
 - `NEXT_PUBLIC_MARKETPLACE_COLLECTIONS`
   - comma-separated `address|name|projectId` entries
+- `NEXT_PUBLIC_SITE_URL`
+  - absolute app URL used for canonical links and OG/Twitter metadata URLs
 
 Example:
 
@@ -41,6 +43,7 @@ Example:
 NEXT_PUBLIC_MARKETPLACE_CHAIN_ID=SN_SEPOLIA
 NEXT_PUBLIC_MARKETPLACE_DEFAULT_PROJECT=
 NEXT_PUBLIC_MARKETPLACE_COLLECTIONS=0x123...|Genesis|project-a,0x456...|Artifacts|project-b
+NEXT_PUBLIC_SITE_URL=https://market.realms.world
 ```
 
 ## Scripts

--- a/src/app/collections/[address]/[tokenId]/opengraph-image.tsx
+++ b/src/app/collections/[address]/[tokenId]/opengraph-image.tsx
@@ -1,0 +1,68 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ address: string; tokenId: string }>;
+}) {
+  const { address, tokenId } = await params;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#09090b",
+          color: "#fafafa",
+          padding: "56px",
+          fontFamily: "ui-sans-serif, system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 28,
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            color: "#a1a1aa",
+          }}
+        >
+          {address}
+        </div>
+
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 700,
+            lineHeight: 1.1,
+            maxWidth: "88%",
+          }}
+        >
+          Token #{tokenId}
+        </div>
+
+        <div
+          style={{
+            fontSize: 30,
+            color: "#d4d4d8",
+          }}
+        >
+          Token
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  );
+}

--- a/src/app/collections/[address]/[tokenId]/page.metadata.test.ts
+++ b/src/app/collections/[address]/[tokenId]/page.metadata.test.ts
@@ -1,0 +1,88 @@
+import type { Metadata } from "next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetTokenSeoData } = vi.hoisted(() => ({
+  mockGetTokenSeoData: vi.fn(),
+}));
+
+vi.mock("@/lib/marketplace/seo-data", () => ({
+  getTokenSeoData: mockGetTokenSeoData,
+}));
+
+vi.mock("@/features/token/token-detail-view", () => ({
+  TokenDetailView: () => null,
+}));
+
+describe("token page metadata", () => {
+  beforeEach(() => {
+    mockGetTokenSeoData.mockReset();
+    process.env.NEXT_PUBLIC_SITE_URL = "https://market.realms.world";
+  });
+
+  it("sets_dynamic_metadata_with_token_image", async () => {
+    mockGetTokenSeoData.mockResolvedValue({
+      exists: true,
+      tokenName: "Dragon #42",
+      collectionName: "Genesis",
+      description: "View listings and activity for Dragon #42.",
+      image: "https://cdn.example.com/token-42.png",
+      collectionImage: "https://cdn.example.com/collection.png",
+    });
+
+    const { generateMetadata } = await import("@/app/collections/[address]/[tokenId]/page");
+    const metadata = (await generateMetadata({
+      params: Promise.resolve({ address: "0xabc", tokenId: "42" }),
+    })) as Metadata;
+
+    expect(metadata.title).toBe("Dragon #42 | Genesis | Realms.market");
+    expect(metadata.description).toBe("View listings and activity for Dragon #42.");
+    expect(metadata.alternates?.canonical).toBe("https://market.realms.world/collections/0xabc/42");
+    expect(metadata.openGraph?.images).toEqual(["https://cdn.example.com/token-42.png"]);
+    expect(metadata.twitter?.images).toEqual(["https://cdn.example.com/token-42.png"]);
+    expect(metadata.robots).toEqual({ index: true, follow: true });
+  });
+
+  it("falls_back_to_collection_image_when_token_image_missing", async () => {
+    mockGetTokenSeoData.mockResolvedValue({
+      exists: true,
+      tokenName: "Dragon #7",
+      collectionName: "Genesis",
+      description: "View listings and activity for Dragon #7.",
+      image: null,
+      collectionImage: "https://cdn.example.com/collection.png",
+    });
+
+    const { generateMetadata } = await import("@/app/collections/[address]/[tokenId]/page");
+    const metadata = (await generateMetadata({
+      params: Promise.resolve({ address: "0xabc", tokenId: "7" }),
+    })) as Metadata;
+
+    expect(metadata.openGraph?.images).toEqual(["https://cdn.example.com/collection.png"]);
+    expect(metadata.twitter?.images).toEqual(["https://cdn.example.com/collection.png"]);
+  });
+
+  it("falls_back_to_generated_og_image_and_noindex_when_token_missing", async () => {
+    mockGetTokenSeoData.mockResolvedValue({
+      exists: false,
+      tokenName: "Token #999",
+      collectionName: "Genesis",
+      description: null,
+      image: null,
+      collectionImage: null,
+    });
+
+    const { generateMetadata } = await import("@/app/collections/[address]/[tokenId]/page");
+    const metadata = (await generateMetadata({
+      params: Promise.resolve({ address: "0xabc", tokenId: "999" }),
+    })) as Metadata;
+
+    expect(metadata.title).toBe("Token #999 | Genesis | Realms.market");
+    expect(metadata.openGraph?.images).toEqual([
+      "https://market.realms.world/collections/0xabc/999/opengraph-image",
+    ]);
+    expect(metadata.twitter?.images).toEqual([
+      "https://market.realms.world/collections/0xabc/999/opengraph-image",
+    ]);
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/collections/[address]/[tokenId]/page.tsx
+++ b/src/app/collections/[address]/[tokenId]/page.tsx
@@ -1,4 +1,6 @@
+import type { Metadata } from "next";
 import { TokenDetailView } from "@/features/token/token-detail-view";
+import { buildMarketplacePageMetadata } from "@/lib/seo/metadata";
 
 type TokenPageProps = {
   params: Promise<{ address: string; tokenId: string }>;
@@ -12,4 +14,25 @@ export default async function TokenPage({ params }: TokenPageProps) {
       <TokenDetailView address={address} tokenId={tokenId} />
     </main>
   );
+}
+
+export async function generateMetadata({
+  params,
+}: TokenPageProps): Promise<Metadata> {
+  const { address, tokenId } = await params;
+  const { getTokenSeoData } = await import("@/lib/marketplace/seo-data");
+  const seoData = await getTokenSeoData(address, tokenId);
+
+  return buildMarketplacePageMetadata({
+    title: `${seoData.tokenName} | ${seoData.collectionName} | Realms.market`,
+    description:
+      seoData.description ??
+      `View listings and activity for ${seoData.tokenName}.`,
+    pathname: `/collections/${address}/${tokenId}`,
+    image:
+      seoData.image ??
+      seoData.collectionImage ??
+      `/collections/${address}/${tokenId}/opengraph-image`,
+    noIndex: !seoData.exists,
+  });
 }

--- a/src/app/collections/[address]/opengraph-image.tsx
+++ b/src/app/collections/[address]/opengraph-image.tsx
@@ -1,0 +1,69 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ address: string }>;
+}) {
+  const { address } = await params;
+  const title = `Collection ${address}`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#09090b",
+          color: "#fafafa",
+          padding: "56px",
+          fontFamily: "ui-sans-serif, system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 28,
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            color: "#a1a1aa",
+          }}
+        >
+          Realms.market
+        </div>
+
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 700,
+            lineHeight: 1.1,
+            maxWidth: "88%",
+          }}
+        >
+          {title}
+        </div>
+
+        <div
+          style={{
+            fontSize: 30,
+            color: "#d4d4d8",
+          }}
+        >
+          Collection
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  );
+}

--- a/src/app/collections/[address]/page.metadata.test.ts
+++ b/src/app/collections/[address]/page.metadata.test.ts
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetCollectionSeoData } = vi.hoisted(() => ({
+  mockGetCollectionSeoData: vi.fn(),
+}));
+
+vi.mock("@/lib/marketplace/seo-data", () => ({
+  getCollectionSeoData: mockGetCollectionSeoData,
+}));
+
+vi.mock("@/features/collections/collection-route-container", () => ({
+  CollectionRouteContainer: () => null,
+}));
+
+describe("collection page metadata", () => {
+  beforeEach(() => {
+    mockGetCollectionSeoData.mockReset();
+    process.env.NEXT_PUBLIC_SITE_URL = "https://market.realms.world";
+  });
+
+  it("sets_dynamic_metadata_with_collection_image", async () => {
+    mockGetCollectionSeoData.mockResolvedValue({
+      exists: true,
+      name: "Genesis",
+      description: "Genesis artifacts marketplace",
+      image: "https://cdn.example.com/genesis.png",
+    });
+
+    const { generateMetadata } = await import("@/app/collections/[address]/page");
+    const metadata = (await generateMetadata({
+      params: Promise.resolve({ address: "0xabc" }),
+      searchParams: Promise.resolve({}),
+    })) as Metadata;
+
+    expect(metadata.title).toBe("Genesis | Realms.market");
+    expect(metadata.description).toBe("Genesis artifacts marketplace");
+    expect(metadata.alternates?.canonical).toBe("https://market.realms.world/collections/0xabc");
+    expect(metadata.openGraph?.images).toEqual(["https://cdn.example.com/genesis.png"]);
+    expect(metadata.twitter?.images).toEqual(["https://cdn.example.com/genesis.png"]);
+    expect(metadata.robots).toEqual({ index: true, follow: true });
+  });
+
+  it("falls_back_to_generated_og_image_and_noindex_when_collection_missing", async () => {
+    mockGetCollectionSeoData.mockResolvedValue({
+      exists: false,
+      name: "0x404",
+      description: null,
+      image: null,
+    });
+
+    const { generateMetadata } = await import("@/app/collections/[address]/page");
+    const metadata = (await generateMetadata({
+      params: Promise.resolve({ address: "0x404" }),
+      searchParams: Promise.resolve({}),
+    })) as Metadata;
+
+    expect(metadata.title).toBe("Collection 0x404 | Realms.market");
+    expect(metadata.openGraph?.images).toEqual([
+      "https://market.realms.world/collections/0x404/opengraph-image",
+    ]);
+    expect(metadata.twitter?.images).toEqual([
+      "https://market.realms.world/collections/0x404/opengraph-image",
+    ]);
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/src/app/collections/[address]/page.tsx
+++ b/src/app/collections/[address]/page.tsx
@@ -1,4 +1,6 @@
+import type { Metadata } from "next";
 import { CollectionRouteContainer } from "@/features/collections/collection-route-container";
+import { buildMarketplacePageMetadata } from "@/lib/seo/metadata";
 
 type CollectionPageProps = {
   params: Promise<{ address: string }>;
@@ -17,4 +19,26 @@ export default async function CollectionPage({
       <CollectionRouteContainer address={address} cursor={cursor ?? null} />
     </main>
   );
+}
+
+export async function generateMetadata({
+  params,
+}: CollectionPageProps): Promise<Metadata> {
+  const { address } = await params;
+  const { getCollectionSeoData } = await import("@/lib/marketplace/seo-data");
+  const seoData = await getCollectionSeoData(address);
+
+  return buildMarketplacePageMetadata({
+    title: seoData.exists
+      ? `${seoData.name} | Realms.market`
+      : `Collection ${seoData.name} | Realms.market`,
+    description:
+      seoData.description ??
+      (seoData.exists
+        ? `Explore listings and activity for ${seoData.name}.`
+        : `Collection ${seoData.name} is unavailable on Realms.market.`),
+    pathname: `/collections/${address}`,
+    image: seoData.image ?? `/collections/${address}/opengraph-image`,
+    noIndex: !seoData.exists,
+  });
 }

--- a/src/lib/marketplace/seo-data.test.ts
+++ b/src/lib/marketplace/seo-data.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCreateMarketplaceClient,
+  mockGetCollection,
+  mockGetToken,
+  mockRuntimeConfig,
+} = vi.hoisted(() => ({
+  mockCreateMarketplaceClient: vi.fn(),
+  mockGetCollection: vi.fn(),
+  mockGetToken: vi.fn(),
+  mockRuntimeConfig: {
+    chainLabel: "SN_SEPOLIA",
+    warnings: [],
+    sdkConfig: {
+      chainId: "0x534e5f5345504f4c4941",
+    },
+    collections: [
+      { address: "0xabc", name: "Genesis", projectId: "project-a" },
+    ],
+  },
+}));
+
+vi.mock("@cartridge/arcade/marketplace", () => ({
+  createMarketplaceClient: mockCreateMarketplaceClient,
+}));
+
+vi.mock("@/lib/marketplace/config", () => ({
+  getMarketplaceRuntimeConfig: () => mockRuntimeConfig,
+}));
+
+describe("marketplace seo data", () => {
+  beforeEach(() => {
+    mockGetCollection.mockReset();
+    mockGetToken.mockReset();
+    mockCreateMarketplaceClient.mockReset();
+    mockCreateMarketplaceClient.mockReturnValue({
+      getCollection: mockGetCollection,
+      getToken: mockGetToken,
+    });
+  });
+
+  it("returns_collection_name_description_and_image", async () => {
+    mockGetCollection.mockResolvedValue({
+      address: "0xabc",
+      metadata: {
+        name: "Genesis",
+        description: "A flagship collection",
+        image: "https://cdn.example.com/genesis.png",
+      },
+    });
+
+    const { getCollectionSeoData } = await import("@/lib/marketplace/seo-data");
+    const result = await getCollectionSeoData("0xabc");
+
+    expect(result).toEqual({
+      exists: true,
+      name: "Genesis",
+      description: "A flagship collection",
+      image: "https://cdn.example.com/genesis.png",
+    });
+    expect(mockGetCollection).toHaveBeenCalledWith({
+      address: "0xabc",
+      projectId: "project-a",
+      fetchImages: true,
+    });
+  });
+
+  it("retries_token_lookup_with_alternate_id_format", async () => {
+    mockGetCollection.mockResolvedValue({
+      address: "0xabc",
+      metadata: {
+        name: "Genesis",
+        image: "https://cdn.example.com/genesis.png",
+      },
+    });
+    mockGetToken
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        token: {
+          token_id: "0x935",
+          metadata: {
+            name: "Loot Chest #2357",
+            image: "https://cdn.example.com/2357.png",
+          },
+          image: null,
+        },
+      });
+
+    const { getTokenSeoData } = await import("@/lib/marketplace/seo-data");
+    const result = await getTokenSeoData("0xabc", "2357");
+
+    expect(result).toEqual({
+      exists: true,
+      tokenName: "Loot Chest #2357",
+      collectionName: "Genesis",
+      description: "View listings and activity for Loot Chest #2357.",
+      image: "https://cdn.example.com/2357.png",
+      collectionImage: "https://cdn.example.com/genesis.png",
+    });
+    expect(mockGetToken).toHaveBeenNthCalledWith(1, {
+      collection: "0xabc",
+      tokenId: "2357",
+      projectId: "project-a",
+      fetchImages: true,
+    });
+    expect(mockGetToken).toHaveBeenNthCalledWith(2, {
+      collection: "0xabc",
+      tokenId: "0x935",
+      projectId: "project-a",
+      fetchImages: true,
+    });
+  });
+
+  it("returns_noindex_fallback_payload_when_token_not_found", async () => {
+    mockGetCollection.mockResolvedValue({
+      address: "0xabc",
+      metadata: {
+        name: "Genesis",
+      },
+    });
+    mockGetToken.mockResolvedValue(null);
+
+    const { getTokenSeoData } = await import("@/lib/marketplace/seo-data");
+    const result = await getTokenSeoData("0xabc", "999");
+
+    expect(result).toEqual({
+      exists: false,
+      tokenName: "Token #999",
+      collectionName: "Genesis",
+      description: null,
+      image: null,
+      collectionImage: null,
+    });
+  });
+});

--- a/src/lib/marketplace/seo-data.ts
+++ b/src/lib/marketplace/seo-data.ts
@@ -1,0 +1,248 @@
+import { cache } from "react";
+import type { NormalizedToken, TokenDetails } from "@cartridge/arcade/marketplace";
+import { createMarketplaceClient } from "@cartridge/arcade/marketplace";
+import { getMarketplaceRuntimeConfig } from "@/lib/marketplace/config";
+import { tokenImage, tokenName } from "@/lib/marketplace/token-display";
+
+type CollectionSeoData = {
+  exists: boolean;
+  name: string;
+  description: string | null;
+  image: string | null;
+};
+
+type TokenSeoData = {
+  exists: boolean;
+  tokenName: string;
+  collectionName: string;
+  description: string | null;
+  image: string | null;
+  collectionImage: string | null;
+};
+
+function asRecord(value: unknown) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeImageUrl(value: unknown) {
+  const source = asNonEmptyString(value);
+  if (!source) {
+    return null;
+  }
+
+  if (/^https?:\/\//i.test(source)) {
+    return source;
+  }
+
+  if (source.startsWith("ipfs://")) {
+    return `https://ipfs.io/ipfs/${source.slice("ipfs://".length)}`;
+  }
+
+  return null;
+}
+
+function alternateTokenId(rawTokenId: string) {
+  const tokenId = rawTokenId.trim();
+  if (!tokenId) {
+    return null;
+  }
+
+  if (/^0x[0-9a-fA-F]+$/.test(tokenId)) {
+    try {
+      return BigInt(tokenId).toString();
+    } catch {
+      return null;
+    }
+  }
+
+  if (/^\d+$/.test(tokenId)) {
+    try {
+      return `0x${BigInt(tokenId).toString(16)}`;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function hasUsableToken(data: TokenDetails | null): data is TokenDetails {
+  return data !== null && data.token !== null && data.token !== undefined;
+}
+
+function resolveCollectionContext(address: string) {
+  const config = getMarketplaceRuntimeConfig();
+  const knownCollection = config.collections.find(
+    (entry) => entry.address.toLowerCase() === address.toLowerCase(),
+  );
+
+  return {
+    name: knownCollection?.name ?? address,
+    projectId: knownCollection?.projectId,
+  };
+}
+
+function collectionMetadata(rawCollection: unknown) {
+  const fields = asRecord(rawCollection);
+  const metadata = asRecord(fields?.metadata);
+
+  const name = asNonEmptyString(metadata?.name);
+  const description = asNonEmptyString(metadata?.description);
+  const image =
+    normalizeImageUrl(fields?.image) ??
+    normalizeImageUrl(metadata?.image) ??
+    normalizeImageUrl(metadata?.image_url);
+
+  return {
+    name,
+    description,
+    image,
+  };
+}
+
+const getMarketplaceClient = cache(() => {
+  const { sdkConfig } = getMarketplaceRuntimeConfig();
+  return createMarketplaceClient(sdkConfig);
+});
+
+async function fetchCollection(address: string) {
+  const context = resolveCollectionContext(address);
+  const client = await getMarketplaceClient();
+
+  try {
+    const collection = await client.getCollection({
+      address,
+      projectId: context.projectId,
+      fetchImages: true,
+    });
+
+    return {
+      context,
+      collection,
+    };
+  } catch {
+    return {
+      context,
+      collection: null,
+    };
+  }
+}
+
+async function fetchTokenWithFallback(options: {
+  collection: string;
+  tokenId: string;
+  projectId?: string;
+}) {
+  const client = await getMarketplaceClient();
+  let response: TokenDetails | null = null;
+
+  try {
+    response = await client.getToken({
+      collection: options.collection,
+      tokenId: options.tokenId,
+      projectId: options.projectId,
+      fetchImages: true,
+    });
+  } catch {
+    response = null;
+  }
+
+  if (hasUsableToken(response)) {
+    return response;
+  }
+
+  const fallbackTokenId = alternateTokenId(options.tokenId);
+  if (!fallbackTokenId || fallbackTokenId === options.tokenId) {
+    return null;
+  }
+
+  try {
+    const fallbackResponse = await client.getToken({
+      collection: options.collection,
+      tokenId: fallbackTokenId,
+      projectId: options.projectId,
+      fetchImages: true,
+    });
+
+    return hasUsableToken(fallbackResponse) ? fallbackResponse : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizedTokenImage(token: NormalizedToken) {
+  return normalizeImageUrl(tokenImage(token));
+}
+
+export async function getCollectionSeoData(address: string): Promise<CollectionSeoData> {
+  const { context, collection } = await fetchCollection(address);
+
+  if (!collection) {
+    return {
+      exists: false,
+      name: context.name,
+      description: null,
+      image: null,
+    };
+  }
+
+  const metadata = collectionMetadata(collection);
+
+  return {
+    exists: true,
+    name: metadata.name ?? context.name,
+    description: metadata.description,
+    image: metadata.image,
+  };
+}
+
+export async function getTokenSeoData(
+  address: string,
+  tokenId: string,
+): Promise<TokenSeoData> {
+  const { context, collection } = await fetchCollection(address);
+  const collectionInfo = collectionMetadata(collection);
+  const collectionName = collectionInfo.name ?? context.name;
+  const collectionImage = collectionInfo.image;
+
+  const tokenDetail = await fetchTokenWithFallback({
+    collection: address,
+    tokenId,
+    projectId: context.projectId,
+  });
+
+  if (!tokenDetail?.token) {
+    return {
+      exists: false,
+      tokenName: `Token #${tokenId}`,
+      collectionName,
+      description: null,
+      image: null,
+      collectionImage,
+    };
+  }
+
+  const resolvedTokenName = tokenName(tokenDetail.token);
+
+  return {
+    exists: true,
+    tokenName: resolvedTokenName,
+    collectionName,
+    description: `View listings and activity for ${resolvedTokenName}.`,
+    image: normalizedTokenImage(tokenDetail.token),
+    collectionImage,
+  };
+}

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import { toAbsoluteUrl } from "@/lib/seo/site-url";
+
+type BuildMetadataOptions = {
+  title: string;
+  description: string;
+  pathname: string;
+  image: string;
+  noIndex?: boolean;
+};
+
+function resolveImageUrl(image: string) {
+  if (/^https?:\/\//i.test(image)) {
+    return image;
+  }
+
+  return toAbsoluteUrl(image);
+}
+
+export function buildMarketplacePageMetadata({
+  title,
+  description,
+  pathname,
+  image,
+  noIndex = false,
+}: BuildMetadataOptions): Metadata {
+  const canonical = toAbsoluteUrl(pathname);
+  const imageUrl = resolveImageUrl(image);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      url: canonical,
+      siteName: "Realms.market",
+      images: [imageUrl],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [imageUrl],
+    },
+    robots: {
+      index: !noIndex,
+      follow: !noIndex,
+    },
+  };
+}

--- a/src/lib/seo/site-url.ts
+++ b/src/lib/seo/site-url.ts
@@ -1,0 +1,23 @@
+const DEFAULT_SITE_URL = "http://localhost:3000";
+
+function normalizedBase(rawValue: string | undefined) {
+  const value = rawValue?.trim();
+  if (!value) {
+    return new URL(DEFAULT_SITE_URL);
+  }
+
+  try {
+    return new URL(value.endsWith("/") ? value : `${value}/`);
+  } catch {
+    return new URL(DEFAULT_SITE_URL);
+  }
+}
+
+export function getSiteUrl() {
+  return normalizedBase(process.env.NEXT_PUBLIC_SITE_URL);
+}
+
+export function toAbsoluteUrl(pathname: string) {
+  const normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return new URL(normalizedPath, getSiteUrl()).toString();
+}


### PR DESCRIPTION
Adds dynamic metadata generation for `/collections/[address]` and `/collections/[address]/[tokenId]` with canonical URLs, OpenGraph/Twitter tags, and `noindex` handling for missing entities.
Introduces a server SEO data layer that resolves collection/token names and images (including token ID format fallback) and shared URL/metadata helpers for consistent absolute tags.
Adds minimal text-card dynamic OG image endpoints for both collection and token routes to guarantee fallback metadata images.
Includes route metadata and SEO data tests plus README environment docs for `NEXT_PUBLIC_SITE_URL`, and all checks passed locally (`typecheck`, `test`, `build`).