### PR TITLE
fix: prevent metadata 500s on client init failure

### DIFF
--- a/src/lib/marketplace/seo-data.test.ts
+++ b/src/lib/marketplace/seo-data.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/lib/marketplace/config", () => ({
 
 describe("marketplace seo data", () => {
   beforeEach(() => {
+    vi.resetModules();
     mockGetCollection.mockReset();
     mockGetToken.mockReset();
     mockCreateMarketplaceClient.mockReset();
@@ -132,5 +133,41 @@ describe("marketplace seo data", () => {
       image: null,
       collectionImage: null,
     });
+  });
+
+  it("returns_collection_fallback_when_client_init_fails", async () => {
+    mockCreateMarketplaceClient.mockImplementation(() => {
+      throw new Error("init failed");
+    });
+
+    const { getCollectionSeoData } = await import("@/lib/marketplace/seo-data");
+    const result = await getCollectionSeoData("0xabc");
+
+    expect(result).toEqual({
+      exists: false,
+      name: "Genesis",
+      description: null,
+      image: null,
+    });
+    expect(mockGetCollection).not.toHaveBeenCalled();
+  });
+
+  it("returns_token_fallback_when_client_init_fails", async () => {
+    mockCreateMarketplaceClient.mockImplementation(() => {
+      throw new Error("init failed");
+    });
+
+    const { getTokenSeoData } = await import("@/lib/marketplace/seo-data");
+    const result = await getTokenSeoData("0xabc", "7");
+
+    expect(result).toEqual({
+      exists: false,
+      tokenName: "Token #7",
+      collectionName: "Genesis",
+      description: null,
+      image: null,
+      collectionImage: null,
+    });
+    expect(mockGetToken).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/marketplace/seo-data.ts
+++ b/src/lib/marketplace/seo-data.ts
@@ -118,9 +118,24 @@ const getMarketplaceClient = cache(() => {
   return createMarketplaceClient(sdkConfig);
 });
 
+async function getMarketplaceClientSafe() {
+  try {
+    return await getMarketplaceClient();
+  } catch {
+    return null;
+  }
+}
+
 async function fetchCollection(address: string) {
   const context = resolveCollectionContext(address);
-  const client = await getMarketplaceClient();
+  const client = await getMarketplaceClientSafe();
+
+  if (!client) {
+    return {
+      context,
+      collection: null,
+    };
+  }
 
   try {
     const collection = await client.getCollection({
@@ -146,7 +161,11 @@ async function fetchTokenWithFallback(options: {
   tokenId: string;
   projectId?: string;
 }) {
-  const client = await getMarketplaceClient();
+  const client = await getMarketplaceClientSafe();
+  if (!client) {
+    return null;
+  }
+
   let response: TokenDetails | null = null;
 
   try {


### PR DESCRIPTION
This PR hardens server-side metadata generation for collection and token pages when Arcade client initialization fails.
It adds a safe client getter in src/lib/marketplace/seo-data.ts and returns fallback SEO payloads instead of throwing, preventing 500s on /collections/[address] and /collections/[address]/[tokenId].
It also adds regression tests for client-init failure paths and resets module state in tests to avoid cache leakage.
Verification: npm test -- src/lib/marketplace/seo-data.test.ts; npm test -- 'src/app/collections/[address]/page.metadata.test.ts' 'src/app/collections/[address]/[tokenId]/page.metadata.test.ts'; npm run build.