### PR TITLE
feat(marketplace): add unstable_cache sdk read proxy

### DIFF
--- a/docs/SDK-CACHE-PRD-TDD.md
+++ b/docs/SDK-CACHE-PRD-TDD.md
@@ -1,0 +1,325 @@
+# Marketplace SDK Shared Cache PRD + TDD Plan
+
+Version: 1.0  
+Date: February 19, 2026  
+Status: Approved for implementation scoping  
+Owner: Marketplace team
+
+## 1. Objective
+
+Introduce a shared server-side cache between client UI and Arcade Marketplace SDK reads to reduce indexer load and improve user-perceived latency.
+
+Decision for this phase:
+- Use Next.js `unstable_cache` only.
+- Keep wallet/portfolio reads (`useMarketplaceTokenBalances`) out of scope.
+
+## 2. Problem Statement
+
+Current read paths invoke SDK/indexer queries directly from client hooks, which causes:
+1. Duplicate cross-user requests for identical market data.
+2. Unnecessary indexer pressure under concurrent traffic.
+3. Variable latency on collection pages, filters, and token detail surfaces.
+
+Client-side React Query cache exists but is user/session-local and does not provide shared cache benefits.
+
+## 3. Goals and Success Metrics
+
+### 3.1 Product Goals
+1. Reduce repeated indexer requests for common marketplace reads.
+2. Improve responsiveness of collection/home/token pages under real traffic.
+3. Preserve current UX semantics and query behavior.
+
+### 3.2 Performance Targets
+1. Shared cache hit ratio for eligible endpoints: >= 70% under steady traffic.
+2. p95 response time reduction for cached reads:
+   - trait metadata endpoints: >= 40% vs uncached baseline
+   - collection/listings/token endpoints: >= 25% vs uncached baseline
+3. SDK/indexer request volume reduction for eligible reads: >= 50% vs baseline.
+
+### 3.3 Quality Guardrails
+1. No regression in route behavior, loading states, or error states.
+2. No stale data windows beyond defined TTLs.
+3. No changes to write transaction flows.
+
+## 4. Scope
+
+### 4.1 In Scope
+1. Add internal server API routes for marketplace reads currently fetched in client hooks.
+2. Back each route with `unstable_cache` keyed by normalized request params.
+3. Apply per-resource TTL policy:
+   - Trait/filter metadata: 1 hour.
+   - Collection/market/token reads: 15 seconds.
+4. Migrate eligible hooks to call internal API routes instead of SDK client methods directly.
+5. Add route-level observability (cache hit/miss markers).
+
+### 4.2 Explicitly Out of Scope
+1. Wallet/portfolio reads and ownership balance reads powered by `useMarketplaceTokenBalances`.
+   - Includes `useWalletPortfolioQuery`, `useTokenOwnershipQuery`, `useTokenHolderQuery`.
+2. Checkout/list/offer/cancel transaction execution paths.
+3. External cache infrastructure (Redis/Upstash/Cloudflare) in this phase.
+4. Full protocol-level invalidation beyond TTL expiry.
+
+## 5. Current-State Callsite Inventory
+
+Eligible reads currently in `src/lib/marketplace/hooks.ts` and related views:
+1. `useCollectionQuery` -> `client.getCollection`
+2. `useCollectionTokensQuery` -> `client.listCollectionTokens`
+3. `useCollectionOrdersQuery` -> `client.getCollectionOrders`
+4. `useCollectionListingsQuery` -> `client.listCollectionListings`
+5. `useTokenDetailQuery` -> `client.getToken`
+6. `useCollectionTraitMetadataQuery` -> `fetchCollectionTraitMetadata` + `aggregateTraitMetadata`
+7. Token detail fee card (`src/features/token/token-detail-view.tsx`) -> `client.getFees`, `client.getRoyaltyFee`
+8. SEO metadata (`src/lib/marketplace/seo-data.ts`) -> `client.getCollection`, `client.getToken`
+
+## 6. Target Architecture
+
+## 6.1 Read Path
+1. Browser component hook calls internal route (`/api/marketplace/...`).
+2. Route handler validates request params.
+3. Route calls cached server function wrapped with `unstable_cache`.
+4. Cached function executes SDK call on miss/stale, returns normalized payload.
+5. Route returns JSON plus cache diagnostics headers.
+
+## 6.2 Cache Strategy
+1. `unstable_cache` used per resource with deterministic key parts.
+2. Key parts include all response-shaping params.
+3. TTL via `revalidate`:
+   - 3600 for trait metadata
+   - 15 for collection/tokens/orders/listings/token-detail/fees
+4. Optional tags for future invalidation, but tag-driven invalidation is not required in this phase.
+
+## 6.3 API Surface (New)
+
+1. `GET /api/marketplace/collection`
+   - Params: `address`, optional `projectId`, optional `fetchImages`
+   - TTL: 15s
+2. `GET /api/marketplace/collection-tokens`
+   - Params: `address`, optional `project`, `cursor`, `limit`, `tokenIds[]`, `attributeFilters`
+   - TTL: 15s
+3. `GET /api/marketplace/collection-orders`
+   - Params: `collection`, optional `status`, `category`, `tokenId`, `limit`
+   - TTL: 15s
+4. `GET /api/marketplace/collection-listings`
+   - Params: `collection`, optional `tokenId`, `projectId`, `verifyOwnership`, `limit`
+   - TTL: 15s
+5. `GET /api/marketplace/token-detail`
+   - Params: `collection`, `tokenId`, optional `projectId`, optional `fetchImages`
+   - TTL: 15s
+   - Preserves token-id fallback behavior (decimal <-> hex)
+6. `GET /api/marketplace/collection-trait-metadata`
+   - Params: `address`, optional `projectId`
+   - TTL: 3600s
+7. `GET /api/marketplace/token-fees`
+   - Params: `collection`, `tokenId`, `amount`
+   - TTL: 15s
+   - Returns marketplace fee, royalty fee, total
+
+## 7. Functional Requirements
+
+### FR-CACHE-01 Shared Read Caching
+1. All in-scope read endpoints must be served from server routes.
+2. Server routes must cache by normalized query parameters.
+3. Cache must be shared across users.
+
+Acceptance Criteria:
+1. Hook requests no longer call SDK methods directly for in-scope reads.
+2. Repeated equivalent requests within TTL avoid duplicate SDK calls.
+
+### FR-CACHE-02 TTL Policy Enforcement
+1. Trait metadata responses must use 1-hour TTL.
+2. Collection/market/token/fees responses must use 15-second TTL.
+
+Acceptance Criteria:
+1. TTL values are centralized constants and covered by tests.
+2. Route handlers apply correct TTL by endpoint.
+
+### FR-CACHE-03 Query Determinism
+1. Cache keys must be stable for semantically equivalent params.
+2. Collection token filters and token ID arrays must be normalized before keying.
+
+Acceptance Criteria:
+1. Different parameter ordering does not create duplicate cache entries.
+2. Equivalent filter payloads map to same cache key.
+
+### FR-CACHE-04 UX and Behavior Parity
+1. Existing loading, error, and success states must remain unchanged.
+2. Existing fallback logic for transient token fetch issues must remain intact.
+
+Acceptance Criteria:
+1. Hook tests remain green with route-backed data.
+2. UI feature tests retain behavior without snapshot regressions.
+
+### FR-CACHE-05 Scope Boundary Integrity
+1. Wallet and portfolio reads must remain direct and unchanged.
+2. Ownership checks tied to token balances remain unchanged.
+
+Acceptance Criteria:
+1. `useWalletPortfolioQuery`, `useTokenOwnershipQuery`, `useTokenHolderQuery` are not migrated.
+2. Portfolio/profile/ownership tests pass unchanged unless only selector or plumbing updates are required.
+
+## 8. Non-Functional Requirements
+
+1. Type safety: strict TypeScript; no new `any`.
+2. Reliability: API route errors return structured response with stable `message`.
+3. Security: validate and sanitize query params before SDK calls.
+4. Observability: add cache diagnostics headers:
+   - `x-market-cache`: `hit` | `miss`
+   - `x-market-cache-key`: hash or redacted key id (non-sensitive)
+
+## 9. Data and Error Contracts
+
+1. Route responses should preserve current hook-consumed shape whenever possible.
+2. Failures should return `4xx` for invalid params, `5xx` for upstream/SDK failures.
+3. Hook wrappers must convert non-2xx responses into thrown Errors with useful message.
+4. Do not leak secrets/internal stack traces in API payloads.
+
+## 10. Rollout Plan
+
+### Phase 1 (Foundation)
+1. Add cache constants and key-normalization utilities.
+2. Add server SDK client helper used by route handlers.
+3. Implement and test trait metadata route (1h TTL).
+
+### Phase 2 (Core Read Routes)
+1. Add collection/tokens/orders/listings/token-detail routes with 15s TTL.
+2. Migrate corresponding hooks to route-backed fetch.
+3. Preserve existing retry/fallback semantics.
+
+### Phase 3 (Fee + SEO + Hardening)
+1. Add token-fees route with 15s TTL.
+2. Migrate token detail fee loading to route.
+3. Reuse route-level cached helpers in SEO data fetch flow.
+4. Add diagnostics coverage and finalize docs.
+
+## 11. Detailed TDD Execution Plan
+
+## 11.1 Test Order (Mandatory)
+For each ticket:
+1. RED: write failing test for one behavior.
+2. Verify RED: run targeted test and confirm expected failure reason.
+3. GREEN: implement minimum code to pass.
+4. Verify GREEN: rerun targeted test and adjacent suite.
+5. REFACTOR: cleanup only with tests green.
+
+## 11.2 Test Matrix
+
+### Unit Tests
+1. `src/lib/marketplace/cache-policy.test.ts`
+   - verifies TTL constants (15s, 1h)
+   - verifies endpoint-to-TTL mapping
+2. `src/lib/marketplace/cache-keys.test.ts`
+   - stable key serialization for token arrays and attribute filters
+   - semantic equivalence assertions
+3. `src/lib/marketplace/server-client.test.ts`
+   - SDK client lazy init and error handling
+
+### Route Tests (Integration)
+1. `src/app/api/marketplace/collection-trait-metadata/route.test.ts`
+   - repeated calls with same params hit cache within TTL
+   - cache miss after TTL window (time-mocked)
+2. Equivalent tests for collection/tokens/orders/listings/token-detail/token-fees routes.
+3. Validation tests for missing/invalid params returning `400`.
+
+### Hook Tests
+1. Update `src/lib/marketplace/hooks.test.ts` to verify internal route fetch calls.
+2. Preserve behavior tests for:
+   - collection token fallback retry without images
+   - token detail alternate ID fallback
+   - transient retry policy
+
+### Feature Integration Tests
+1. Collection and token feature tests continue passing with route-backed hooks.
+2. Token detail fee card tests verify route payload integration.
+
+### E2E Smoke
+1. Load `/`, `/collections/[address]`, `/collections/[address]/[tokenId]` and verify functional behavior unchanged.
+2. Optional network assertion: no direct browser-side calls to indexer domain for in-scope reads.
+
+## 11.3 Ticket Backlog (TDD First)
+
+### CACHE-001 Cache Policy and Key Utilities
+- RED tests:
+  - TTL mapping and key normalization equivalence.
+- GREEN:
+  - implement `cache-policy.ts` and `cache-keys.ts`.
+- REFACTOR:
+  - remove duplicate serialization logic from hooks.
+
+### CACHE-002 Trait Metadata Cached Route (1h)
+- RED tests:
+  - route validation and TTL behavior.
+- GREEN:
+  - route + cached SDK call with `revalidate: 3600`.
+- REFACTOR:
+  - extract route helpers for response/error shaping.
+
+### CACHE-003 Core Collection Routes (15s)
+- RED tests:
+  - each route returns expected payload and validates params.
+- GREEN:
+  - add collection/tokens/orders/listings/token-detail routes with `revalidate: 15`.
+- REFACTOR:
+  - share common request parsing.
+
+### CACHE-004 Hook Migration to Internal Routes
+- RED tests:
+  - hooks fail while still expecting old SDK path.
+- GREEN:
+  - migrate in-scope hook queryFns to `fetch` internal API.
+- REFACTOR:
+  - centralize fetch helper and error parser.
+
+### CACHE-005 Fee Route + Token Detail Migration
+- RED tests:
+  - fee-card behavior uses route payload for marketplace/royalty/total.
+- GREEN:
+  - add token-fees route, wire token detail view.
+- REFACTOR:
+  - share fee parsing helpers.
+
+### CACHE-006 SEO Cache Alignment
+- RED tests:
+  - metadata functions use cached server helper and preserve fallback behavior.
+- GREEN:
+  - route/helper reuse in `seo-data.ts`.
+- REFACTOR:
+  - dedupe token fallback logic.
+
+### CACHE-007 Hardening + Regression Gate
+- RED tests:
+  - diagnostics headers and error contract tests.
+- GREEN:
+  - finalize headers and docs.
+- REFACTOR:
+  - streamline naming and constants.
+
+## 12. Acceptance Criteria (Release)
+
+1. All in-scope SDK reads are routed through internal cached endpoints.
+2. Trait metadata TTL is 1 hour; other in-scope reads are 15 seconds.
+3. Wallet/portfolio/ownership token-balance reads remain unchanged.
+4. `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` pass.
+5. No behavior regression on home, collection, token detail, cart fee card.
+
+## 13. Risks and Mitigations
+
+1. Risk: `unstable_cache` behavior differs across deployment modes.
+   - Mitigation: integration tests in CI + observability headers in production.
+2. Risk: Over-caching stale listings for active trading.
+   - Mitigation: strict 15s TTL and explicit refresh controls preserved.
+3. Risk: Cache key cardinality explosion from unnormalized filters.
+   - Mitigation: deterministic param normalization and unit tests.
+4. Risk: Hidden regressions from hook transport swap.
+   - Mitigation: preserve existing hook test suite semantics before refactor.
+
+## 14. Open Questions
+
+1. Should route handlers expose an optional `cache=skip` debug query param for ops only?
+2. Do we want explicit cache tags now (`revalidateTag`) for future write-trigger invalidation, or defer fully?
+3. Should SEO endpoints share the exact same cache key helper as app routes in this phase or a follow-up?
+
+## 15. Implementation Notes for This Phase
+
+1. Use `unstable_cache` as the only shared cache mechanism.
+2. Do not introduce Redis/Upstash or external cache services.
+3. Do not migrate wallet/portfolio/token-balance reads in this scope.

--- a/src/app/api/marketplace/collection-listings/route.ts
+++ b/src/app/api/marketplace/collection-listings/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  nonEmptyParam,
+  optionalBooleanParam,
+  optionalNumberParam,
+  routeError,
+} from "@/lib/marketplace/api-route";
+import {
+  cacheControlHeader,
+  getCachedCollectionListings,
+} from "@/lib/marketplace/server-read";
+
+export async function GET(request: NextRequest) {
+  const collection = nonEmptyParam(request.nextUrl.searchParams.get("collection"));
+  if (!collection) {
+    return routeError("Missing collection.", 400);
+  }
+
+  const tokenId = nonEmptyParam(request.nextUrl.searchParams.get("tokenId")) ?? undefined;
+  const projectId = nonEmptyParam(request.nextUrl.searchParams.get("projectId")) ?? undefined;
+  const verifyOwnership = optionalBooleanParam(request.nextUrl.searchParams.get("verifyOwnership"));
+  const limit = optionalNumberParam(request.nextUrl.searchParams.get("limit"));
+
+  try {
+    const payload = await getCachedCollectionListings({
+      collection,
+      tokenId,
+      projectId,
+      verifyOwnership,
+      limit,
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        "cache-control": cacheControlHeader("collectionListings"),
+      },
+    });
+  } catch {
+    return routeError("Failed to load collection listings.", 500);
+  }
+}

--- a/src/app/api/marketplace/collection-orders/route.ts
+++ b/src/app/api/marketplace/collection-orders/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { CollectionOrdersOptions } from "@cartridge/arcade/marketplace";
+import {
+  nonEmptyParam,
+  optionalNumberParam,
+  routeError,
+} from "@/lib/marketplace/api-route";
+import {
+  cacheControlHeader,
+  getCachedCollectionOrders,
+} from "@/lib/marketplace/server-read";
+
+export async function GET(request: NextRequest) {
+  const collection = nonEmptyParam(request.nextUrl.searchParams.get("collection"));
+  if (!collection) {
+    return routeError("Missing collection.", 400);
+  }
+
+  const status = (nonEmptyParam(request.nextUrl.searchParams.get("status")) ??
+    undefined) as CollectionOrdersOptions["status"];
+  const category = (nonEmptyParam(request.nextUrl.searchParams.get("category")) ??
+    undefined) as CollectionOrdersOptions["category"];
+  const tokenId = nonEmptyParam(request.nextUrl.searchParams.get("tokenId")) ?? undefined;
+  const limit = optionalNumberParam(request.nextUrl.searchParams.get("limit"));
+
+  try {
+    const payload = await getCachedCollectionOrders({
+      collection,
+      status,
+      category,
+      tokenId,
+      limit,
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        "cache-control": cacheControlHeader("collectionOrders"),
+      },
+    });
+  } catch {
+    return routeError("Failed to load collection orders.", 500);
+  }
+}

--- a/src/app/api/marketplace/collection-tokens/route.ts
+++ b/src/app/api/marketplace/collection-tokens/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { FetchCollectionTokensOptions } from "@cartridge/arcade/marketplace";
+import {
+  nonEmptyParam,
+  optionalBooleanParam,
+  optionalNumberParam,
+  parseCommaSeparated,
+  parseJsonObject,
+  routeError,
+} from "@/lib/marketplace/api-route";
+import {
+  cacheControlHeader,
+  getCachedCollectionTokens,
+} from "@/lib/marketplace/server-read";
+
+export async function GET(request: NextRequest) {
+  const address = nonEmptyParam(request.nextUrl.searchParams.get("address"));
+  if (!address) {
+    return routeError("Missing address.", 400);
+  }
+
+  const rawAttributeFilters = request.nextUrl.searchParams.get("attributeFilters");
+  const attributeFilters = parseJsonObject(rawAttributeFilters);
+  if (rawAttributeFilters && !attributeFilters) {
+    return routeError("Invalid attributeFilters.", 400);
+  }
+
+  const options = {
+    address,
+    project: nonEmptyParam(request.nextUrl.searchParams.get("project")) ?? undefined,
+    cursor: nonEmptyParam(request.nextUrl.searchParams.get("cursor")) ?? undefined,
+    limit: optionalNumberParam(request.nextUrl.searchParams.get("limit")),
+    tokenIds: parseCommaSeparated(request.nextUrl.searchParams.get("tokenIds")),
+    fetchImages: optionalBooleanParam(request.nextUrl.searchParams.get("fetchImages")),
+    attributeFilters:
+      attributeFilters as FetchCollectionTokensOptions["attributeFilters"],
+  } satisfies FetchCollectionTokensOptions;
+
+  try {
+    const payload = await getCachedCollectionTokens(options);
+
+    return NextResponse.json(payload, {
+      headers: {
+        "cache-control": cacheControlHeader("collectionTokens"),
+      },
+    });
+  } catch {
+    return routeError("Failed to load collection tokens.", 500);
+  }
+}

--- a/src/app/api/marketplace/collection-trait-metadata/route.ts
+++ b/src/app/api/marketplace/collection-trait-metadata/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { nonEmptyParam, routeError } from "@/lib/marketplace/api-route";
+import {
+  cacheControlHeader,
+  getCachedCollectionTraitMetadata,
+} from "@/lib/marketplace/server-read";
+
+export async function GET(request: NextRequest) {
+  const address = nonEmptyParam(request.nextUrl.searchParams.get("address"));
+  if (!address) {
+    return routeError("Missing address.", 400);
+  }
+
+  const projectId = nonEmptyParam(request.nextUrl.searchParams.get("projectId")) ?? undefined;
+
+  try {
+    const payload = await getCachedCollectionTraitMetadata({
+      address,
+      projectId,
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        "cache-control": cacheControlHeader("collectionTraitMetadata"),
+      },
+    });
+  } catch {
+    return routeError("Failed to load trait metadata.", 500);
+  }
+}

--- a/src/app/api/marketplace/collection/route.ts
+++ b/src/app/api/marketplace/collection/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { nonEmptyParam, optionalBooleanParam, routeError } from "@/lib/marketplace/api-route";
+import { cacheControlHeader, getCachedCollection } from "@/lib/marketplace/server-read";
+
+export async function GET(request: NextRequest) {
+  const address = nonEmptyParam(request.nextUrl.searchParams.get("address"));
+  if (!address) {
+    return routeError("Missing address.", 400);
+  }
+
+  const projectId = nonEmptyParam(request.nextUrl.searchParams.get("projectId")) ?? undefined;
+  const fetchImages = optionalBooleanParam(request.nextUrl.searchParams.get("fetchImages"));
+
+  try {
+    const payload = await getCachedCollection({
+      address,
+      projectId,
+      fetchImages,
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        "cache-control": cacheControlHeader("collection"),
+      },
+    });
+  } catch {
+    return routeError("Failed to load collection.", 500);
+  }
+}

--- a/src/app/api/marketplace/token-detail/route.ts
+++ b/src/app/api/marketplace/token-detail/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { nonEmptyParam, optionalBooleanParam, routeError } from "@/lib/marketplace/api-route";
+import { cacheControlHeader, getCachedTokenDetail } from "@/lib/marketplace/server-read";
+
+export async function GET(request: NextRequest) {
+  const collection = nonEmptyParam(request.nextUrl.searchParams.get("collection"));
+  const tokenId = nonEmptyParam(request.nextUrl.searchParams.get("tokenId"));
+  if (!collection || !tokenId) {
+    return routeError("Missing collection or tokenId.", 400);
+  }
+
+  const projectId = nonEmptyParam(request.nextUrl.searchParams.get("projectId")) ?? undefined;
+  const fetchImages = optionalBooleanParam(request.nextUrl.searchParams.get("fetchImages"));
+
+  try {
+    const payload = await getCachedTokenDetail({
+      collection,
+      tokenId,
+      projectId,
+      fetchImages,
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        "cache-control": cacheControlHeader("tokenDetail"),
+      },
+    });
+  } catch {
+    return routeError("Failed to load token detail.", 500);
+  }
+}

--- a/src/app/api/marketplace/token-fees/route.ts
+++ b/src/app/api/marketplace/token-fees/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { nonEmptyParam, routeError } from "@/lib/marketplace/api-route";
+import { cacheControlHeader, getCachedTokenFees } from "@/lib/marketplace/server-read";
+
+export async function GET(request: NextRequest) {
+  const collection = nonEmptyParam(request.nextUrl.searchParams.get("collection"));
+  const tokenId = nonEmptyParam(request.nextUrl.searchParams.get("tokenId"));
+  const amount = nonEmptyParam(request.nextUrl.searchParams.get("amount"));
+  if (!collection || !tokenId || !amount) {
+    return routeError("Missing collection, tokenId, or amount.", 400);
+  }
+
+  try {
+    const payload = await getCachedTokenFees({
+      collection,
+      tokenId,
+      amount,
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        "cache-control": cacheControlHeader("tokenFees"),
+      },
+    });
+  } catch {
+    return routeError("Failed to load token fees.", 500);
+  }
+}

--- a/src/features/token/token-detail-view.test.tsx
+++ b/src/features/token/token-detail-view.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { TokenDetailView } from "@/features/token/token-detail-view";
 
 const { mockUseTokenDetailQuery, mockUseCollectionListingsQuery } = vi.hoisted(() => ({
@@ -20,10 +20,8 @@ const { mockUseTokenOwnershipQuery } = vi.hoisted(() => ({
 const { mockUseTokenHolderQuery } = vi.hoisted(() => ({
   mockUseTokenHolderQuery: vi.fn(),
 }));
-const { mockUseMarketplaceClient, mockGetFees, mockGetRoyaltyFee } = vi.hoisted(() => ({
-  mockUseMarketplaceClient: vi.fn(),
-  mockGetFees: vi.fn(),
-  mockGetRoyaltyFee: vi.fn(),
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
 }));
 
 vi.mock("@/lib/marketplace/hooks", () => ({
@@ -35,10 +33,6 @@ vi.mock("@/lib/marketplace/hooks", () => ({
 
 vi.mock("@starknet-react/core", () => ({
   useAccount: mockUseAccount,
-}));
-
-vi.mock("@cartridge/arcade/marketplace/react", () => ({
-  useMarketplaceClient: mockUseMarketplaceClient,
 }));
 
 vi.mock("@/features/cart/store/cart-store", () => ({
@@ -124,6 +118,8 @@ function ownershipLoadingQuery() {
 
 describe("token detail view", () => {
   beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
     mockUseTokenDetailQuery.mockReset();
     mockUseCollectionListingsQuery.mockReset();
     mockUseAccount.mockReset();
@@ -131,9 +127,6 @@ describe("token detail view", () => {
     mockCartSetOpen.mockReset();
     mockCartAddItem.mockReturnValue({ ok: true });
     mockUseTokenOwnershipQuery.mockReset();
-    mockUseMarketplaceClient.mockReset();
-    mockGetFees.mockReset();
-    mockGetRoyaltyFee.mockReset();
     mockUseCollectionListingsQuery.mockReturnValue(successListingsQuery([]));
     mockUseAccount.mockReturnValue({
       account: undefined,
@@ -155,25 +148,30 @@ describe("token detail view", () => {
       isFetching: false,
       refresh: vi.fn(),
     });
-    mockGetFees.mockResolvedValue({
-      feeNum: 500,
-      feeDenominator: 10_000,
-      feeReceiver: "0xfee-receiver",
-    });
-    mockGetRoyaltyFee.mockResolvedValue({
-      receiver: "0xroyalty-receiver",
-      amount: BigInt(0),
-    });
-    mockUseMarketplaceClient.mockReturnValue({
-      client: {
-        getFees: mockGetFees,
-        getRoyaltyFee: mockGetRoyaltyFee,
-      },
-      status: "ready",
-      error: null,
-      refresh: vi.fn(),
-    });
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          marketplaceFee: "0",
+          royaltyFee: "0",
+          total: "100",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
   });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function pendingFeeResponse() {
+    return new Promise<Response>(() => {
+      // intentionally unresolved
+    });
+  }
 
   it("renders_token_name_and_image", () => {
     mockUseTokenDetailQuery.mockReturnValue(
@@ -349,8 +347,7 @@ describe("token detail view", () => {
   });
 
   it("shows_fee_estimate_loading_state", async () => {
-    mockGetFees.mockReturnValue(new Promise(() => {}));
-    mockGetRoyaltyFee.mockReturnValue(new Promise(() => {}));
+    mockFetch.mockReturnValue(pendingFeeResponse());
     mockUseCollectionListingsQuery.mockReturnValue(
       successListingsQuery([
         {
@@ -382,7 +379,7 @@ describe("token detail view", () => {
   });
 
   it("shows_fee_estimate_error_state_when_sdk_calls_fail", async () => {
-    mockGetFees.mockRejectedValue(new Error("fee endpoint unavailable"));
+    mockFetch.mockRejectedValue(new Error("fee endpoint unavailable"));
     mockUseCollectionListingsQuery.mockReturnValue(
       successListingsQuery([
         {
@@ -413,16 +410,20 @@ describe("token detail view", () => {
     expect(await screen.findByTestId("token-fee-error")).toBeVisible();
   });
 
-  it("renders_fee_estimate_breakdown_from_sdk_values", async () => {
-    mockGetFees.mockResolvedValue({
-      feeNum: 250,
-      feeDenominator: 10_000,
-      feeReceiver: "0xfee-receiver",
-    });
-    mockGetRoyaltyFee.mockResolvedValue({
-      receiver: "0xroyalty-receiver",
-      amount: BigInt(7),
-    });
+  it("renders_fee_estimate_breakdown_from_api_values", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          marketplaceFee: "2",
+          royaltyFee: "7",
+          total: "109",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
     mockUseCollectionListingsQuery.mockReturnValue(
       successListingsQuery([
         {

--- a/src/features/token/token-detail-view.tsx
+++ b/src/features/token/token-detail-view.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useAccount } from "@starknet-react/core";
 import type { NormalizedToken } from "@cartridge/arcade/marketplace";
-import { useMarketplaceClient } from "@cartridge/arcade/marketplace/react";
 import {
   useCollectionListingsQuery,
   useTokenDetailQuery,
@@ -30,6 +29,7 @@ import {
   formatPriceForDisplay,
 } from "@/lib/marketplace/token-display";
 import { calculateMarketplaceFee, parseBigInt } from "@/lib/marketplace/fees";
+import { marketplaceApiGet } from "@/lib/marketplace/read-api";
 import type { CheapestListing } from "@/features/cart/listing-utils";
 import {
   cartItemFromTokenListing,
@@ -127,7 +127,6 @@ export function TokenDetailView({
   const normalizedTokenId = formatNumberish(tokenId) ?? tokenId;
   const { addListingToCart, isRecentlyAdded } = useAddToCartFeedback();
   const { account, address: walletAddress, isConnected } = useAccount();
-  const { client } = useMarketplaceClient();
   const { collections } = getMarketplaceRuntimeConfig();
   const collectionName = collections.find((c) => c.address === address)?.name ?? address;
   const [verifyOwnership, setVerifyOwnership] = useState(false);
@@ -240,42 +239,45 @@ export function TokenDetailView({
       }));
 
       try {
-        const fees =
-          client && typeof client.getFees === "function"
-            ? await client.getFees()
-            : null;
-        const marketplaceFee = calculateMarketplaceFee(listingPrice, {
-          feeNum: fees?.feeNum ?? DEFAULT_MARKETPLACE_FEE_NUM,
-          feeDenominator: fees?.feeDenominator ?? DEFAULT_MARKETPLACE_FEE_DENOMINATOR,
+        const feeResponse = await marketplaceApiGet<{
+          marketplaceFee: string;
+          royaltyFee: string;
+          total: string;
+        }>("/api/marketplace/token-fees", {
+          collection: address,
+          tokenId: formatNumberish(token.token_id) ?? String(token.token_id),
+          amount: listingPrice.toString(),
         });
-
-        const royaltyResponse =
-          client && typeof client.getRoyaltyFee === "function"
-            ? await client.getRoyaltyFee({
-              collection: address,
-              tokenId: formatNumberish(token.token_id) ?? String(token.token_id),
-              amount: listingPrice,
-            })
-            : null;
 
         if (disposed) {
           return;
         }
 
-        const royaltyFee = royaltyResponse?.amount ?? BigInt(0);
+        const marketplaceFee = parseBigInt(feeResponse.marketplaceFee);
+        const royaltyFee = parseBigInt(feeResponse.royaltyFee);
+        const total = parseBigInt(feeResponse.total);
+        if (marketplaceFee === null || royaltyFee === null || total === null) {
+          throw new Error("Invalid fee response.");
+        }
+
         setFeeEstimate({
           status: "success",
           marketplaceFee,
           royaltyFee,
-          total: listingPrice + marketplaceFee + royaltyFee,
+          total,
         });
       } catch {
+        const fallbackMarketplaceFee = calculateMarketplaceFee(listingPrice, {
+          feeNum: DEFAULT_MARKETPLACE_FEE_NUM,
+          feeDenominator: DEFAULT_MARKETPLACE_FEE_DENOMINATOR,
+        });
+
         if (!disposed) {
           setFeeEstimate({
             status: "error",
-            marketplaceFee: BigInt(0),
+            marketplaceFee: fallbackMarketplaceFee,
             royaltyFee: BigInt(0),
-            total: BigInt(0),
+            total: listingPrice + fallbackMarketplaceFee,
           });
         }
       }
@@ -286,7 +288,7 @@ export function TokenDetailView({
     return () => {
       disposed = true;
     };
-  }, [address, cheapestListing, client, token]);
+  }, [address, cheapestListing, token]);
 
   // If existing listings use a specific currency, adopt it (otherwise keep STRK default).
   useEffect(() => {

--- a/src/lib/marketplace/api-route.ts
+++ b/src/lib/marketplace/api-route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+
+export function routeError(message: string, status: number) {
+  return NextResponse.json({ message }, { status });
+}
+
+export function nonEmptyParam(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function optionalBooleanParam(value: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  return undefined;
+}
+
+export function optionalNumberParam(value: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+
+  return Math.floor(parsed);
+}
+
+export function parseCommaSeparated(value: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const entries = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  return entries.length > 0 ? entries : undefined;
+}
+
+export function parseJsonObject(value: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/marketplace/cache-keys.test.ts
+++ b/src/lib/marketplace/cache-keys.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeAttributeFilters,
+  normalizeTokenIds,
+  stableCacheKey,
+} from "@/lib/marketplace/cache-keys";
+
+describe("marketplace cache keys", () => {
+  it("normalizes token id arrays deterministically", () => {
+    expect(normalizeTokenIds(["7", "0xabc", "7", "2"])).toEqual(["0xabc", "2", "7"]);
+  });
+
+  it("normalizes attribute filters deterministically", () => {
+    const actual = normalizeAttributeFilters({
+      Background: ["Blue", "Blue", "Red"],
+      Eyes: new Set(["Laser", "Normal"]),
+    });
+
+    expect(actual).toEqual({
+      Background: ["Blue", "Red"],
+      Eyes: ["Laser", "Normal"],
+    });
+  });
+
+  it("creates the same key for semantically equivalent objects", () => {
+    const a = stableCacheKey({
+      address: "0xabc",
+      tokenIds: ["2", "1"],
+      attributeFilters: { B: ["2", "1"], A: ["3"] },
+    });
+    const b = stableCacheKey({
+      attributeFilters: { A: ["3"], B: ["1", "2"] },
+      tokenIds: ["1", "2"],
+      address: "0xabc",
+    });
+
+    expect(a).toBe(b);
+  });
+});

--- a/src/lib/marketplace/cache-keys.ts
+++ b/src/lib/marketplace/cache-keys.ts
@@ -1,0 +1,81 @@
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => String(entry).trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function normalizeTokenIds(tokenIds: unknown) {
+  return Array.from(new Set(asStringArray(tokenIds))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+function normalizeStringSetLike(value: unknown) {
+  if (value instanceof Set) {
+    return Array.from(value)
+      .map((entry) => String(entry).trim())
+      .filter((entry) => entry.length > 0);
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => String(entry).trim())
+      .filter((entry) => entry.length > 0);
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    return normalized.length > 0 ? [normalized] : [];
+  }
+
+  return [];
+}
+
+export function normalizeAttributeFilters(filters: unknown) {
+  if (!filters || typeof filters !== "object") {
+    return undefined;
+  }
+
+  const normalized = Object.entries(filters as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .reduce<Record<string, string[]>>((acc, [traitName, values]) => {
+      const deduped = Array.from(new Set(normalizeStringSetLike(values))).sort((a, b) =>
+        a.localeCompare(b),
+      );
+
+      if (deduped.length > 0) {
+        acc[traitName] = deduped;
+      }
+
+      return acc;
+    }, {});
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeForKey(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => normalizeForKey(entry))
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .reduce<Record<string, unknown>>((acc, [key, entry]) => {
+        acc[key] = normalizeForKey(entry);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
+export function stableCacheKey(value: unknown) {
+  return JSON.stringify(normalizeForKey(value));
+}

--- a/src/lib/marketplace/cache-policy.test.ts
+++ b/src/lib/marketplace/cache-policy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  MARKETPLACE_CACHE_TTL_SECONDS,
+  cacheTtlForResource,
+  type MarketplaceCacheResource,
+} from "@/lib/marketplace/cache-policy";
+
+describe("marketplace cache policy", () => {
+  it("defines required ttl constants", () => {
+    expect(MARKETPLACE_CACHE_TTL_SECONDS.collection).toBe(15);
+    expect(MARKETPLACE_CACHE_TTL_SECONDS.traitMetadata).toBe(3600);
+  });
+
+  it("maps resources to expected ttl", () => {
+    const collectionResources: MarketplaceCacheResource[] = [
+      "collection",
+      "collectionTokens",
+      "collectionOrders",
+      "collectionListings",
+      "tokenDetail",
+      "tokenFees",
+    ];
+
+    collectionResources.forEach((resource) => {
+      expect(cacheTtlForResource(resource)).toBe(15);
+    });
+
+    expect(cacheTtlForResource("collectionTraitMetadata")).toBe(3600);
+  });
+});

--- a/src/lib/marketplace/cache-policy.ts
+++ b/src/lib/marketplace/cache-policy.ts
@@ -1,0 +1,21 @@
+export const MARKETPLACE_CACHE_TTL_SECONDS = {
+  collection: 15,
+  traitMetadata: 60 * 60,
+} as const;
+
+export type MarketplaceCacheResource =
+  | "collection"
+  | "collectionTokens"
+  | "collectionOrders"
+  | "collectionListings"
+  | "tokenDetail"
+  | "tokenFees"
+  | "collectionTraitMetadata";
+
+export function cacheTtlForResource(resource: MarketplaceCacheResource) {
+  if (resource === "collectionTraitMetadata") {
+    return MARKETPLACE_CACHE_TTL_SECONDS.traitMetadata;
+  }
+
+  return MARKETPLACE_CACHE_TTL_SECONDS.collection;
+}

--- a/src/lib/marketplace/hooks.test.ts
+++ b/src/lib/marketplace/hooks.test.ts
@@ -2,15 +2,13 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 import type { CollectionOrdersOptions } from "@cartridge/arcade/marketplace";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
-const { mockUseMarketplaceClient, mockUseMarketplaceTokenBalances } = vi.hoisted(() => ({
-  mockUseMarketplaceClient: vi.fn(),
+const { mockUseMarketplaceTokenBalances } = vi.hoisted(() => ({
   mockUseMarketplaceTokenBalances: vi.fn(),
 }));
 
 vi.mock("@cartridge/arcade/marketplace/react", () => ({
-  useMarketplaceClient: mockUseMarketplaceClient,
   useMarketplaceTokenBalances: mockUseMarketplaceTokenBalances,
 }));
 
@@ -25,56 +23,63 @@ function makeWrapper() {
   return QueryWrapper;
 }
 
-function mockClient(overrides: Record<string, unknown> = {}) {
-  return {
-    getCollection: vi.fn().mockResolvedValue(null),
-    listCollectionTokens: vi.fn().mockResolvedValue({ page: null, error: null }),
-    getCollectionOrders: vi.fn().mockResolvedValue([]),
-    listCollectionListings: vi.fn().mockResolvedValue([]),
-    getToken: vi.fn().mockResolvedValue(null),
-    ...overrides,
-  };
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
 }
 
 describe("marketplace cached hooks", () => {
+  const fetchMock = vi.fn();
+
   beforeEach(() => {
-    mockUseMarketplaceClient.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
     mockUseMarketplaceTokenBalances.mockReset();
     mockUseMarketplaceTokenBalances.mockReturnValue({ data: [], isLoading: false });
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe("useCollectionQuery", () => {
-    it("fetches_collection_via_client", async () => {
+    it("fetches_collection_from_internal_api", async () => {
       const collection = { address: "0xabc", contractType: "erc721" };
-      const client = mockClient({
-        getCollection: vi.fn().mockResolvedValue(collection),
-      });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
+      fetchMock.mockImplementation(() => jsonResponse(collection));
 
       const { useCollectionQuery } = await import("@/lib/marketplace/hooks");
       const { result } = renderHook(
-        () => useCollectionQuery({ address: "0xabc", fetchImages: true }),
+        () =>
+          useCollectionQuery({
+            address: "0xabc",
+            projectId: "project-a",
+            fetchImages: true,
+          }),
         { wrapper: makeWrapper() },
       );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(collection);
-      expect(client.getCollection).toHaveBeenCalledWith({
-        address: "0xabc",
-        fetchImages: true,
-      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const requestUrl = String(fetchMock.mock.calls[0][0]);
+      expect(requestUrl).toContain("/api/marketplace/collection?");
+      expect(requestUrl).toContain("address=0xabc");
+      expect(requestUrl).toContain("projectId=project-a");
+      expect(requestUrl).toContain("fetchImages=true");
     });
 
-    it("stays_disabled_when_client_not_ready", async () => {
-      mockUseMarketplaceClient.mockReturnValue({ client: null, status: "idle" });
-
+    it("stays_disabled_when_address_missing", async () => {
       const { useCollectionQuery } = await import("@/lib/marketplace/hooks");
-      const { result } = renderHook(
-        () => useCollectionQuery({ address: "0xabc" }),
-        { wrapper: makeWrapper() },
-      );
+      const { result } = renderHook(() => useCollectionQuery({ address: "" }), {
+        wrapper: makeWrapper(),
+      });
 
       expect(result.current.fetchStatus).toBe("idle");
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 
@@ -84,10 +89,7 @@ describe("marketplace cached hooks", () => {
         page: { tokens: [{ token_id: "1" }], nextCursor: "abc" },
         error: null,
       };
-      const client = mockClient({
-        listCollectionTokens: vi.fn().mockResolvedValue(page),
-      });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
+      fetchMock.mockImplementation(() => jsonResponse(page));
 
       const { useCollectionTokensQuery } = await import(
         "@/lib/marketplace/hooks"
@@ -98,60 +100,23 @@ describe("marketplace cached hooks", () => {
             address: "0xabc",
             limit: 12,
             fetchImages: true,
+            tokenIds: ["7", "2"],
+            attributeFilters: {
+              Background: new Set(["Blue", "Red"]),
+            },
           }),
         { wrapper: makeWrapper() },
       );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data?.page?.tokens).toHaveLength(1);
-      expect(client.listCollectionTokens).toHaveBeenCalledWith({
-        address: "0xabc",
-        limit: 12,
-        fetchImages: true,
-      });
-    });
-
-    it("retries_without_images_on_invalid_content_type_error", async () => {
-      const page = {
-        page: { tokens: [{ token_id: "1" }], nextCursor: null },
-        error: null,
-      };
-      const listCollectionTokens = vi
-        .fn()
-        .mockRejectedValueOnce(
-          new Error(
-            'failed to get tokens: status: Unknown, message: "invalid content type: application/json; charset=utf-8"',
-          ),
-        )
-        .mockResolvedValueOnce(page);
-      const client = mockClient({ listCollectionTokens });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
-
-      const { useCollectionTokensQuery } = await import(
-        "@/lib/marketplace/hooks"
-      );
-      const { result } = renderHook(
-        () =>
-          useCollectionTokensQuery({
-            address: "0xabc",
-            limit: 12,
-            fetchImages: true,
-          }),
-        { wrapper: makeWrapper() },
-      );
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(listCollectionTokens).toHaveBeenNthCalledWith(1, {
-        address: "0xabc",
-        limit: 12,
-        fetchImages: true,
-      });
-      expect(listCollectionTokens).toHaveBeenNthCalledWith(2, {
-        address: "0xabc",
-        limit: 12,
-        fetchImages: false,
-      });
-      expect(result.current.data).toEqual(page);
+      const requestUrl = String(fetchMock.mock.calls[0][0]);
+      expect(requestUrl).toContain("/api/marketplace/collection-tokens?");
+      expect(requestUrl).toContain("address=0xabc");
+      expect(requestUrl).toContain("limit=12");
+      expect(requestUrl).toContain("fetchImages=true");
+      expect(requestUrl).toContain("tokenIds=2%2C7");
+      expect(requestUrl).toContain("attributeFilters=");
     });
 
     it("retries_transient_timeout_errors", async () => {
@@ -159,13 +124,10 @@ describe("marketplace cached hooks", () => {
         page: { tokens: [{ token_id: "2" }], nextCursor: null },
         error: null,
       };
-      const listCollectionTokens = vi
-        .fn()
+      fetchMock
         .mockRejectedValueOnce(new Error("deadline exceeded"))
         .mockRejectedValueOnce(new Error("request timeout"))
-        .mockResolvedValueOnce(page);
-      const client = mockClient({ listCollectionTokens });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
+        .mockImplementationOnce(() => jsonResponse(page));
 
       const { useCollectionTokensQuery } = await import(
         "@/lib/marketplace/hooks"
@@ -181,7 +143,7 @@ describe("marketplace cached hooks", () => {
       );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(listCollectionTokens).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(result.current.data).toEqual(page);
     });
   });
@@ -189,36 +151,33 @@ describe("marketplace cached hooks", () => {
   describe("useCollectionOrdersQuery", () => {
     it("fetches_orders_for_collection", async () => {
       const orders = [{ id: 1, tokenId: 5 }];
-      const client = mockClient({
-        getCollectionOrders: vi.fn().mockResolvedValue(orders),
-      });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
+      fetchMock.mockImplementation(() => jsonResponse(orders));
 
       const { useCollectionOrdersQuery } = await import(
         "@/lib/marketplace/hooks"
       );
       const { result } = renderHook(
         () =>
-          useCollectionOrdersQuery({ collection: "0xabc", status: "Placed" as CollectionOrdersOptions["status"] }),
+          useCollectionOrdersQuery({
+            collection: "0xabc",
+            status: "Placed" as CollectionOrdersOptions["status"],
+          }),
         { wrapper: makeWrapper() },
       );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(orders);
-      expect(client.getCollectionOrders).toHaveBeenCalledWith({
-        collection: "0xabc",
-        status: "Placed",
-      });
+      const requestUrl = String(fetchMock.mock.calls[0][0]);
+      expect(requestUrl).toContain("/api/marketplace/collection-orders?");
+      expect(requestUrl).toContain("collection=0xabc");
+      expect(requestUrl).toContain("status=Placed");
     });
   });
 
   describe("useCollectionListingsQuery", () => {
     it("fetches_listings_for_collection", async () => {
       const listings = [{ id: 2, tokenId: 3 }];
-      const client = mockClient({
-        listCollectionListings: vi.fn().mockResolvedValue(listings),
-      });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
+      fetchMock.mockImplementation(() => jsonResponse(listings));
 
       const { useCollectionListingsQuery } = await import(
         "@/lib/marketplace/hooks"
@@ -235,25 +194,22 @@ describe("marketplace cached hooks", () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(listings);
-      expect(client.listCollectionListings).toHaveBeenCalledWith({
-        collection: "0xabc",
-        tokenId: "5",
-        projectId: "proj-a",
-      });
+      const requestUrl = String(fetchMock.mock.calls[0][0]);
+      expect(requestUrl).toContain("/api/marketplace/collection-listings?");
+      expect(requestUrl).toContain("collection=0xabc");
+      expect(requestUrl).toContain("tokenId=5");
+      expect(requestUrl).toContain("projectId=proj-a");
     });
   });
 
   describe("useTokenDetailQuery", () => {
-    it("fetches_token_detail_via_get_token", async () => {
+    it("fetches_token_detail_from_internal_api", async () => {
       const detail = {
         token: { token_id: "42", metadata: { name: "Dragon" } },
         orders: [],
         listings: [],
       };
-      const client = mockClient({
-        getToken: vi.fn().mockResolvedValue(detail),
-      });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
+      fetchMock.mockImplementation(() => jsonResponse(detail));
 
       const { useTokenDetailQuery } = await import("@/lib/marketplace/hooks");
       const { result } = renderHook(
@@ -268,17 +224,14 @@ describe("marketplace cached hooks", () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual(detail);
-      expect(client.getToken).toHaveBeenCalledWith({
-        collection: "0xabc",
-        tokenId: "42",
-        fetchImages: true,
-      });
+      const requestUrl = String(fetchMock.mock.calls[0][0]);
+      expect(requestUrl).toContain("/api/marketplace/token-detail?");
+      expect(requestUrl).toContain("collection=0xabc");
+      expect(requestUrl).toContain("tokenId=42");
+      expect(requestUrl).toContain("fetchImages=true");
     });
 
     it("stays_disabled_when_no_token_id", async () => {
-      const client = mockClient();
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
-
       const { useTokenDetailQuery } = await import("@/lib/marketplace/hooks");
       const { result } = renderHook(
         () => useTokenDetailQuery({ collection: "0xabc", tokenId: "" }),
@@ -286,128 +239,38 @@ describe("marketplace cached hooks", () => {
       );
 
       expect(result.current.fetchStatus).toBe("idle");
-      expect(client.getToken).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
     });
+  });
 
-    it("retries_with_hex_token_id_when_decimal_lookup_returns_null", async () => {
-      const detail = {
-        token: { token_id: "0x935", metadata: { name: "Loot Chest #2357" } },
-        orders: [],
-        listings: [],
-      };
-      const getToken = vi
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(detail);
-      const client = mockClient({ getToken });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
+  describe("useCollectionTraitMetadataQuery", () => {
+    it("fetches_trait_metadata_from_internal_api", async () => {
+      const data = [{ traitName: "Background", traitValue: "Blue", count: 8 }];
+      fetchMock.mockImplementation(() => jsonResponse(data));
 
-      const { useTokenDetailQuery } = await import("@/lib/marketplace/hooks");
+      const { useCollectionTraitMetadataQuery } = await import(
+        "@/lib/marketplace/hooks"
+      );
       const { result } = renderHook(
         () =>
-          useTokenDetailQuery({
-            collection: "0xloot",
-            tokenId: "2357",
-            fetchImages: true,
+          useCollectionTraitMetadataQuery({
+            address: "0xabc",
+            projectId: "project-a",
           }),
         { wrapper: makeWrapper() },
       );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data).toEqual(detail);
-      expect(getToken).toHaveBeenNthCalledWith(1, {
-        collection: "0xloot",
-        tokenId: "2357",
-        fetchImages: true,
-      });
-      expect(getToken).toHaveBeenNthCalledWith(2, {
-        collection: "0xloot",
-        tokenId: "0x935",
-        fetchImages: true,
-      });
-    });
-
-    it("retries_with_decimal_token_id_when_hex_lookup_returns_null", async () => {
-      const detail = {
-        token: { token_id: "2357", metadata: { name: "Loot Chest #2357" } },
-        orders: [],
-        listings: [],
-      };
-      const getToken = vi
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(detail);
-      const client = mockClient({ getToken });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
-
-      const { useTokenDetailQuery } = await import("@/lib/marketplace/hooks");
-      const { result } = renderHook(
-        () =>
-          useTokenDetailQuery({
-            collection: "0xloot",
-            tokenId: "0x935",
-            fetchImages: true,
-          }),
-        { wrapper: makeWrapper() },
-      );
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data).toEqual(detail);
-      expect(getToken).toHaveBeenNthCalledWith(1, {
-        collection: "0xloot",
-        tokenId: "0x935",
-        fetchImages: true,
-      });
-      expect(getToken).toHaveBeenNthCalledWith(2, {
-        collection: "0xloot",
-        tokenId: "2357",
-        fetchImages: true,
-      });
-    });
-
-    it("retries_with_alternate_token_id_when_first_lookup_throws", async () => {
-      const detail = {
-        token: { token_id: "0x935", metadata: { name: "Loot Chest #2357" } },
-        orders: [],
-        listings: [],
-      };
-      const getToken = vi
-        .fn()
-        .mockRejectedValueOnce(new Error("invalid token format"))
-        .mockResolvedValueOnce(detail);
-      const client = mockClient({ getToken });
-      mockUseMarketplaceClient.mockReturnValue({ client, status: "ready" });
-
-      const { useTokenDetailQuery } = await import("@/lib/marketplace/hooks");
-      const { result } = renderHook(
-        () =>
-          useTokenDetailQuery({
-            collection: "0xloot",
-            tokenId: "2357",
-            fetchImages: true,
-          }),
-        { wrapper: makeWrapper() },
-      );
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data).toEqual(detail);
-      expect(getToken).toHaveBeenNthCalledWith(1, {
-        collection: "0xloot",
-        tokenId: "2357",
-        fetchImages: true,
-      });
-      expect(getToken).toHaveBeenNthCalledWith(2, {
-        collection: "0xloot",
-        tokenId: "0x935",
-        fetchImages: true,
-      });
+      expect(result.current.data).toEqual(data);
+      const requestUrl = String(fetchMock.mock.calls[0][0]);
+      expect(requestUrl).toContain("/api/marketplace/collection-trait-metadata?");
+      expect(requestUrl).toContain("address=0xabc");
+      expect(requestUrl).toContain("projectId=project-a");
     });
   });
 
   describe("useTokenOwnershipQuery", () => {
     it("passes_both_decimal_and_hex_token_ids_when_given_decimal", async () => {
-      mockUseMarketplaceClient.mockReturnValue({ client: {}, status: "ready" });
-
       const { useTokenOwnershipQuery } = await import("@/lib/marketplace/hooks");
       renderHook(
         () =>
@@ -424,76 +287,12 @@ describe("marketplace cached hooks", () => {
           tokenIds: expect.arrayContaining(["2648", "0xa58"]),
         }),
         true,
-      );
-    });
-
-    it("passes_both_hex_and_decimal_token_ids_when_given_hex", async () => {
-      mockUseMarketplaceClient.mockReturnValue({ client: {}, status: "ready" });
-
-      const { useTokenOwnershipQuery } = await import("@/lib/marketplace/hooks");
-      renderHook(
-        () =>
-          useTokenOwnershipQuery({
-            collection: "0xcol",
-            tokenId: "0xa58",
-            accountAddress: "0xabc",
-          }),
-        { wrapper: makeWrapper() },
-      );
-
-      expect(mockUseMarketplaceTokenBalances).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tokenIds: expect.arrayContaining(["0xa58", "2648"]),
-        }),
-        true,
-      );
-    });
-
-    it("stays_disabled_when_no_account_address", async () => {
-      mockUseMarketplaceClient.mockReturnValue({ client: {}, status: "ready" });
-
-      const { useTokenOwnershipQuery } = await import("@/lib/marketplace/hooks");
-      renderHook(
-        () =>
-          useTokenOwnershipQuery({
-            collection: "0xcol",
-            tokenId: "2648",
-          }),
-        { wrapper: makeWrapper() },
-      );
-
-      expect(mockUseMarketplaceTokenBalances).toHaveBeenCalledWith(
-        expect.anything(),
-        false,
       );
     });
   });
 
   describe("useTokenHolderQuery", () => {
-    it("passes_both_decimal_and_hex_token_ids_when_given_decimal", async () => {
-      mockUseMarketplaceClient.mockReturnValue({ client: {}, status: "ready" });
-
-      const { useTokenHolderQuery } = await import("@/lib/marketplace/hooks");
-      renderHook(
-        () =>
-          useTokenHolderQuery({
-            collection: "0xcol",
-            tokenId: "2648",
-          }),
-        { wrapper: makeWrapper() },
-      );
-
-      expect(mockUseMarketplaceTokenBalances).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tokenIds: expect.arrayContaining(["2648", "0xa58"]),
-        }),
-        true,
-      );
-    });
-
     it("passes_both_hex_and_decimal_token_ids_when_given_hex", async () => {
-      mockUseMarketplaceClient.mockReturnValue({ client: {}, status: "ready" });
-
       const { useTokenHolderQuery } = await import("@/lib/marketplace/hooks");
       renderHook(
         () =>
@@ -511,24 +310,23 @@ describe("marketplace cached hooks", () => {
         true,
       );
     });
+  });
 
-    it("stays_disabled_when_collection_missing", async () => {
-      mockUseMarketplaceClient.mockReturnValue({ client: {}, status: "ready" });
-
-      const { useTokenHolderQuery } = await import("@/lib/marketplace/hooks");
-      renderHook(
-        () =>
-          useTokenHolderQuery({
-            collection: "",
-            tokenId: "2648",
-          }),
-        { wrapper: makeWrapper() },
-      );
+  describe("useWalletPortfolioQuery", () => {
+    it("keeps_wallet_portfolio_reads_on_token_balances", async () => {
+      const { useWalletPortfolioQuery } = await import("@/lib/marketplace/hooks");
+      renderHook(() => useWalletPortfolioQuery("0xwallet"), {
+        wrapper: makeWrapper(),
+      });
 
       expect(mockUseMarketplaceTokenBalances).toHaveBeenCalledWith(
-        expect.anything(),
-        false,
+        expect.objectContaining({
+          accountAddresses: ["0xwallet"],
+          limit: 200,
+        }),
+        true,
       );
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/marketplace/hooks.ts
+++ b/src/lib/marketplace/hooks.ts
@@ -6,10 +6,34 @@ import type {
   CollectionOrdersOptions,
   CollectionSummaryOptions,
   FetchCollectionTokensOptions,
+  NormalizedToken,
   TokenDetails,
   TokenDetailsOptions,
 } from "@cartridge/arcade/marketplace";
-import { useMarketplaceClient, useMarketplaceTokenBalances } from "@cartridge/arcade/marketplace/react";
+import { useMarketplaceTokenBalances } from "@cartridge/arcade/marketplace/react";
+import { MARKETPLACE_CACHE_TTL_SECONDS } from "@/lib/marketplace/cache-policy";
+import {
+  normalizeAttributeFilters,
+  normalizeTokenIds,
+  stableCacheKey,
+} from "@/lib/marketplace/cache-keys";
+import {
+  marketplaceApiGet,
+  marketplaceReadParams,
+} from "@/lib/marketplace/read-api";
+
+type CollectionSummaryResult = {
+  totalSupply?: string | number;
+  metadata?: unknown;
+} | null;
+
+type CollectionTokensResult = {
+  page?: {
+    tokens?: NormalizedToken[];
+    nextCursor?: string | null;
+  } | null;
+  error?: unknown;
+} | null;
 
 function logSdkPayload(label: string, options: object, payload: unknown) {
   if (process.env.NODE_ENV !== "development") {
@@ -23,15 +47,11 @@ function logSdkPayload(label: string, options: object, payload: unknown) {
       : undefined;
   const preview = Array.isArray(payload) ? payload.slice(0, 3) : payload;
 
-  console.info(`[marketplace-sdk] ${label}`, {
+  console.info(`[marketplace-api] ${label}`, {
     options,
     count,
     preview,
   });
-}
-
-function hasUsableToken(data: TokenDetails | null): data is TokenDetails {
-  return data !== null && data.token !== null && data.token !== undefined;
 }
 
 function errorMessage(error: unknown) {
@@ -61,27 +81,6 @@ function isTransientCollectionTokenError(error: unknown) {
   );
 }
 
-async function listCollectionTokensResilient(
-  client: NonNullable<ReturnType<typeof useMarketplaceClient>["client"]>,
-  options: FetchCollectionTokensOptions,
-) {
-  try {
-    return await client.listCollectionTokens(options);
-  } catch (initialError) {
-    const shouldRetryWithoutImages =
-      options.fetchImages === true &&
-      isTransientCollectionTokenError(initialError);
-    if (!shouldRetryWithoutImages) {
-      throw initialError;
-    }
-
-    const fallbackOptions = { ...options, fetchImages: false };
-    const fallbackData = await client.listCollectionTokens(fallbackOptions);
-    logSdkPayload("collection-tokens-fallback-no-images", fallbackOptions, fallbackData);
-    return fallbackData;
-  }
-}
-
 function alternateTokenId(rawTokenId: string) {
   const tokenId = rawTokenId.trim();
   if (!tokenId) {
@@ -108,45 +107,57 @@ function alternateTokenId(rawTokenId: string) {
 }
 
 export function useCollectionQuery(options: CollectionSummaryOptions) {
-  const { client } = useMarketplaceClient();
-
-  return useQuery({
+  return useQuery<CollectionSummaryResult>({
     queryKey: ["collection", options.address, options.projectId] as const,
     queryFn: async () => {
-      const data = await client!.getCollection(options);
+      const data = await marketplaceApiGet<CollectionSummaryResult>("/api/marketplace/collection", {
+        address: options.address,
+        projectId: options.projectId,
+        fetchImages: options.fetchImages,
+      });
       logSdkPayload("collection", options, data);
       return data;
     },
-    enabled: !!client && !!options.address,
+    enabled: !!options.address,
+    staleTime: MARKETPLACE_CACHE_TTL_SECONDS.collection * 1000,
   });
 }
 
 export function useCollectionTokensQuery(
   options: FetchCollectionTokensOptions,
 ) {
-  const { client } = useMarketplaceClient();
+  const normalizedTokenIds = normalizeTokenIds(options.tokenIds);
+  const normalizedAttributeFilters = normalizeAttributeFilters(
+    options.attributeFilters,
+  );
 
-  return useQuery({
+  return useQuery<CollectionTokensResult>({
     queryKey: [
       "collection-tokens",
       options.address,
       options.project,
       options.cursor,
-      options.tokenIds,
+      normalizedTokenIds,
       options.limit,
-      options.attributeFilters
-        ? JSON.stringify(
-            Object.fromEntries(
-              Object.entries(options.attributeFilters).map(([k, v]) => [
-                k,
-                Array.from(v as Iterable<unknown>).sort(),
-              ]),
-            ),
-          )
-        : null,
+      stableCacheKey(normalizedAttributeFilters ?? null),
     ] as const,
     queryFn: async () => {
-      const data = await listCollectionTokensResilient(client!, options);
+      const normalizedParams = marketplaceReadParams({
+        tokenIds: options.tokenIds,
+        attributeFilters: options.attributeFilters,
+      });
+      const data = await marketplaceApiGet<CollectionTokensResult>(
+        "/api/marketplace/collection-tokens",
+        {
+          address: options.address,
+          project: options.project,
+          cursor: options.cursor,
+          limit: options.limit,
+          fetchImages: options.fetchImages,
+          tokenIds: normalizedParams.tokenIds,
+          attributeFilters: normalizedParams.attributeFilters,
+        },
+      );
       logSdkPayload("collection-tokens", options, data);
       return data;
     },
@@ -158,13 +169,12 @@ export function useCollectionTokensQuery(
       return failureCount < 1;
     },
     retryDelay: () => 0,
-    enabled: !!client && !!options.address,
+    enabled: !!options.address,
+    staleTime: MARKETPLACE_CACHE_TTL_SECONDS.collection * 1000,
   });
 }
 
 export function useCollectionOrdersQuery(options: CollectionOrdersOptions) {
-  const { client } = useMarketplaceClient();
-
   return useQuery({
     queryKey: [
       "collection-orders",
@@ -174,17 +184,25 @@ export function useCollectionOrdersQuery(options: CollectionOrdersOptions) {
       options.tokenId,
     ] as const,
     queryFn: async () => {
-      const data = await client!.getCollectionOrders(options);
+      const data = await marketplaceApiGet<unknown[]>(
+        "/api/marketplace/collection-orders",
+        {
+          collection: options.collection,
+          status: options.status,
+          category: options.category,
+          tokenId: options.tokenId,
+          limit: options.limit,
+        },
+      );
       logSdkPayload("collection-orders", options, data);
       return data;
     },
-    enabled: !!client && !!options.collection,
+    enabled: !!options.collection,
+    staleTime: MARKETPLACE_CACHE_TTL_SECONDS.collection * 1000,
   });
 }
 
 export function useCollectionListingsQuery(options: CollectionListingsOptions) {
-  const { client } = useMarketplaceClient();
-
   return useQuery({
     queryKey: [
       "collection-listings",
@@ -192,19 +210,28 @@ export function useCollectionListingsQuery(options: CollectionListingsOptions) {
       options.tokenId,
       options.projectId,
       options.verifyOwnership,
+      options.limit,
     ] as const,
     queryFn: async () => {
-      const data = await client!.listCollectionListings(options);
+      const data = await marketplaceApiGet<unknown[]>(
+        "/api/marketplace/collection-listings",
+        {
+          collection: options.collection,
+          tokenId: options.tokenId,
+          projectId: options.projectId,
+          verifyOwnership: options.verifyOwnership,
+          limit: options.limit,
+        },
+      );
       logSdkPayload("collection-listings", options, data);
       return data;
     },
-    enabled: !!client && !!options.collection,
+    enabled: !!options.collection,
+    staleTime: MARKETPLACE_CACHE_TTL_SECONDS.collection * 1000,
   });
 }
 
 export function useTokenDetailQuery(options: TokenDetailsOptions) {
-  const { client } = useMarketplaceClient();
-
   return useQuery({
     queryKey: [
       "token-detail",
@@ -213,45 +240,21 @@ export function useTokenDetailQuery(options: TokenDetailsOptions) {
       options.projectId,
     ] as const,
     queryFn: async (): Promise<TokenDetails | null> => {
-      let data: TokenDetails | null = null;
-      let initialError: unknown = null;
+      const data = await marketplaceApiGet<TokenDetails | null>(
+        "/api/marketplace/token-detail",
+        {
+          collection: options.collection,
+          tokenId: options.tokenId,
+          projectId: options.projectId,
+          fetchImages: options.fetchImages,
+        },
+      );
 
-      try {
-        data = await client!.getToken(options);
-        logSdkPayload("token-detail", options, data);
-      } catch (error) {
-        initialError = error;
-      }
-
-      if (hasUsableToken(data)) {
-        return data;
-      }
-
-      const fallbackTokenId = alternateTokenId(String(options.tokenId));
-      if (!fallbackTokenId || fallbackTokenId === String(options.tokenId)) {
-        if (initialError) {
-          throw initialError;
-        }
-        return data;
-      }
-
-      const fallbackOptions = {
-        ...options,
-        tokenId: fallbackTokenId,
-      };
-      try {
-        const fallbackData = await client!.getToken(fallbackOptions);
-        logSdkPayload("token-detail-fallback", fallbackOptions, fallbackData);
-        return fallbackData;
-      } catch (fallbackError) {
-        if (initialError) {
-          throw initialError;
-        }
-
-        throw fallbackError;
-      }
+      logSdkPayload("token-detail", options, data);
+      return data;
     },
-    enabled: !!client && !!options.collection && !!options.tokenId,
+    enabled: !!options.collection && !!options.tokenId,
+    staleTime: MARKETPLACE_CACHE_TTL_SECONDS.collection * 1000,
   });
 }
 
@@ -280,16 +283,15 @@ export function useCollectionTraitMetadataQuery(options: {
   return useQuery({
     queryKey: ["collection-trait-metadata", options.address, options.projectId] as const,
     queryFn: async () => {
-      const { fetchCollectionTraitMetadata, aggregateTraitMetadata } =
-        await import("@cartridge/arcade/marketplace");
-      const result = await fetchCollectionTraitMetadata({
+      return await marketplaceApiGet<
+        Array<{ traitName: string; traitValue: string; count: number }>
+      >("/api/marketplace/collection-trait-metadata", {
         address: options.address,
-        projects: options.projectId ? [options.projectId] : undefined,
-        defaultProjectId: options.projectId,
+        projectId: options.projectId,
       });
-      return aggregateTraitMetadata(result.pages);
     },
     enabled: !!options.address,
+    staleTime: MARKETPLACE_CACHE_TTL_SECONDS.traitMetadata * 1000,
   });
 }
 

--- a/src/lib/marketplace/read-api.ts
+++ b/src/lib/marketplace/read-api.ts
@@ -1,0 +1,89 @@
+import { normalizeAttributeFilters, normalizeTokenIds } from "@/lib/marketplace/cache-keys";
+
+type QueryParamValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | string[]
+  | Record<string, unknown>;
+
+function appendQueryParam(
+  searchParams: URLSearchParams,
+  key: string,
+  value: QueryParamValue,
+) {
+  if (value === undefined || value === null || value === "") {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return;
+    }
+    searchParams.set(key, value.join(","));
+    return;
+  }
+
+  if (typeof value === "object") {
+    searchParams.set(key, JSON.stringify(value));
+    return;
+  }
+
+  searchParams.set(key, String(value));
+}
+
+function parseErrorPayload(payload: unknown) {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const message = (payload as { message?: unknown }).message;
+  return typeof message === "string" && message.trim().length > 0
+    ? message
+    : null;
+}
+
+export async function marketplaceApiGet<T>(
+  path: string,
+  params: Record<string, QueryParamValue>,
+): Promise<T> {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    appendQueryParam(searchParams, key, value);
+  });
+
+  const queryString = searchParams.toString();
+  const url = queryString ? `${path}?${queryString}` : path;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    let message = `Marketplace read failed (${response.status})`;
+
+    try {
+      const payload = (await response.json()) as unknown;
+      message = parseErrorPayload(payload) ?? message;
+    } catch {
+      // no-op
+    }
+
+    throw new Error(message);
+  }
+
+  return (await response.json()) as T;
+}
+
+export function marketplaceReadParams(options: {
+  tokenIds?: unknown;
+  attributeFilters?: unknown;
+}) {
+  return {
+    tokenIds: normalizeTokenIds(options.tokenIds),
+    attributeFilters: normalizeAttributeFilters(options.attributeFilters),
+  };
+}

--- a/src/lib/marketplace/server-client.ts
+++ b/src/lib/marketplace/server-client.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import { cache } from "react";
+import { getMarketplaceRuntimeConfig } from "@/lib/marketplace/config";
+
+type MarketplaceModule = typeof import("@cartridge/arcade/marketplace");
+type MarketplaceClient = Awaited<
+  ReturnType<MarketplaceModule["createMarketplaceClient"]>
+>;
+
+const loadMarketplaceModule = cache(async (): Promise<MarketplaceModule> => {
+  return await import("@cartridge/arcade/marketplace");
+});
+
+export const getServerMarketplaceClient = cache(
+  async (): Promise<MarketplaceClient> => {
+    const marketplaceModule = await loadMarketplaceModule();
+    const { sdkConfig } = getMarketplaceRuntimeConfig();
+    return await marketplaceModule.createMarketplaceClient(sdkConfig);
+  },
+);

--- a/src/lib/marketplace/server-read.ts
+++ b/src/lib/marketplace/server-read.ts
@@ -1,0 +1,318 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import type {
+  CollectionListingsOptions,
+  CollectionOrdersOptions,
+  CollectionSummaryOptions,
+  FetchCollectionTokensOptions,
+  TokenDetails,
+  TokenDetailsOptions,
+} from "@cartridge/arcade/marketplace";
+import { cacheTtlForResource } from "@/lib/marketplace/cache-policy";
+import {
+  normalizeAttributeFilters,
+  normalizeTokenIds,
+  stableCacheKey,
+} from "@/lib/marketplace/cache-keys";
+import { calculateMarketplaceFee, parseBigInt } from "@/lib/marketplace/fees";
+import { formatNumberish } from "@/lib/marketplace/token-display";
+import { getServerMarketplaceClient } from "@/lib/marketplace/server-client";
+
+type TraitMetadata = {
+  traitName: string;
+  traitValue: string;
+  count: number;
+};
+
+export type TokenFeesResult = {
+  marketplaceFee: string;
+  royaltyFee: string;
+  total: string;
+};
+
+const DEFAULT_MARKETPLACE_FEE_NUM = 500;
+const DEFAULT_MARKETPLACE_FEE_DENOMINATOR = 10_000;
+
+function errorMessage(error: unknown) {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function isTransientCollectionTokenError(error: unknown) {
+  const message = errorMessage(error).toLowerCase();
+  return (
+    message.includes("invalid content type: application/json") ||
+    message.includes("deadline exceeded") ||
+    message.includes("request timeout") ||
+    message.includes("timed out") ||
+    message.includes("timeout")
+  );
+}
+
+async function listCollectionTokensResilient(options: FetchCollectionTokensOptions) {
+  const client = await getServerMarketplaceClient();
+
+  try {
+    return await client.listCollectionTokens(options);
+  } catch (initialError) {
+    const shouldRetryWithoutImages =
+      options.fetchImages === true &&
+      isTransientCollectionTokenError(initialError);
+    if (!shouldRetryWithoutImages) {
+      throw initialError;
+    }
+
+    const fallbackOptions = { ...options, fetchImages: false };
+    return await client.listCollectionTokens(fallbackOptions);
+  }
+}
+
+function alternateTokenId(rawTokenId: string) {
+  const tokenId = rawTokenId.trim();
+  if (!tokenId) {
+    return null;
+  }
+
+  if (/^0x[0-9a-fA-F]+$/.test(tokenId)) {
+    try {
+      return BigInt(tokenId).toString();
+    } catch {
+      return null;
+    }
+  }
+
+  if (/^\d+$/.test(tokenId)) {
+    try {
+      return `0x${BigInt(tokenId).toString(16)}`;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function normalizeFetchCollectionTokensOptions(options: FetchCollectionTokensOptions) {
+  const normalizedTokenIds = normalizeTokenIds(options.tokenIds);
+  const normalizedAttributeFilters = normalizeAttributeFilters(options.attributeFilters);
+
+  const attributeFilters = normalizedAttributeFilters
+    ? Object.fromEntries(
+        Object.entries(normalizedAttributeFilters).map(([key, values]) => [
+          key,
+          new Set(values),
+        ]),
+      )
+    : undefined;
+
+  return {
+    ...options,
+    tokenIds: normalizedTokenIds.length > 0 ? normalizedTokenIds : undefined,
+    attributeFilters,
+  } satisfies FetchCollectionTokensOptions;
+}
+
+const getCollectionCached = unstable_cache(
+  async (
+    _cacheKey: string,
+    options: CollectionSummaryOptions,
+  ): Promise<unknown> => {
+    const client = await getServerMarketplaceClient();
+    return await client.getCollection(options);
+  },
+  ["marketplace", "collection"],
+  { revalidate: cacheTtlForResource("collection") },
+);
+
+const getCollectionTokensCached = unstable_cache(
+  async (
+    _cacheKey: string,
+    options: FetchCollectionTokensOptions,
+  ): Promise<unknown> => {
+    return await listCollectionTokensResilient(options);
+  },
+  ["marketplace", "collection-tokens"],
+  { revalidate: cacheTtlForResource("collectionTokens") },
+);
+
+const getCollectionOrdersCached = unstable_cache(
+  async (
+    _cacheKey: string,
+    options: CollectionOrdersOptions,
+  ): Promise<unknown[]> => {
+    const client = await getServerMarketplaceClient();
+    return await client.getCollectionOrders(options);
+  },
+  ["marketplace", "collection-orders"],
+  { revalidate: cacheTtlForResource("collectionOrders") },
+);
+
+const getCollectionListingsCached = unstable_cache(
+  async (
+    _cacheKey: string,
+    options: CollectionListingsOptions,
+  ): Promise<unknown[]> => {
+    const client = await getServerMarketplaceClient();
+    return await client.listCollectionListings(options);
+  },
+  ["marketplace", "collection-listings"],
+  { revalidate: cacheTtlForResource("collectionListings") },
+);
+
+const getTokenDetailCached = unstable_cache(
+  async (
+    _cacheKey: string,
+    options: TokenDetailsOptions,
+  ): Promise<TokenDetails | null> => {
+    const client = await getServerMarketplaceClient();
+    let data: TokenDetails | null = null;
+    let initialError: unknown = null;
+
+    try {
+      data = await client.getToken(options);
+    } catch (error) {
+      initialError = error;
+    }
+
+    if (data?.token) {
+      return data;
+    }
+
+    const fallbackTokenId = alternateTokenId(String(options.tokenId));
+    if (!fallbackTokenId || fallbackTokenId === String(options.tokenId)) {
+      if (initialError) {
+        throw initialError;
+      }
+      return data;
+    }
+
+    const fallbackOptions = {
+      ...options,
+      tokenId: fallbackTokenId,
+    };
+
+    try {
+      return await client.getToken(fallbackOptions);
+    } catch (fallbackError) {
+      if (initialError) {
+        throw initialError;
+      }
+
+      throw fallbackError;
+    }
+  },
+  ["marketplace", "token-detail"],
+  { revalidate: cacheTtlForResource("tokenDetail") },
+);
+
+const getCollectionTraitMetadataCached = unstable_cache(
+  async (
+    _cacheKey: string,
+    options: { address: string; projectId?: string },
+  ): Promise<TraitMetadata[]> => {
+    const { fetchCollectionTraitMetadata, aggregateTraitMetadata } =
+      await import("@cartridge/arcade/marketplace");
+
+    const result = await fetchCollectionTraitMetadata({
+      address: options.address,
+      projects: options.projectId ? [options.projectId] : undefined,
+      defaultProjectId: options.projectId,
+    });
+
+    return aggregateTraitMetadata(result.pages);
+  },
+  ["marketplace", "collection-trait-metadata"],
+  { revalidate: cacheTtlForResource("collectionTraitMetadata") },
+);
+
+const getTokenFeesCached = unstable_cache(
+  async (
+    _cacheKey: string,
+    options: { collection: string; tokenId: string; amount: string },
+  ): Promise<TokenFeesResult> => {
+    const amount = parseBigInt(options.amount);
+    if (amount === null) {
+      throw new Error("Invalid amount.");
+    }
+
+    const client = await getServerMarketplaceClient();
+    const fees =
+      typeof client.getFees === "function" ? await client.getFees() : null;
+    const marketplaceFee = calculateMarketplaceFee(amount, {
+      feeNum: fees?.feeNum ?? DEFAULT_MARKETPLACE_FEE_NUM,
+      feeDenominator: fees?.feeDenominator ?? DEFAULT_MARKETPLACE_FEE_DENOMINATOR,
+    });
+
+    const royaltyResponse =
+      typeof client.getRoyaltyFee === "function"
+        ? await client.getRoyaltyFee({
+            collection: options.collection,
+            tokenId: formatNumberish(options.tokenId) ?? options.tokenId,
+            amount,
+          })
+        : null;
+
+    const royaltyFee = royaltyResponse?.amount ?? BigInt(0);
+
+    return {
+      marketplaceFee: marketplaceFee.toString(),
+      royaltyFee: royaltyFee.toString(),
+      total: (amount + marketplaceFee + royaltyFee).toString(),
+    };
+  },
+  ["marketplace", "token-fees"],
+  { revalidate: cacheTtlForResource("tokenFees") },
+);
+
+export function cacheControlHeader(resource: Parameters<typeof cacheTtlForResource>[0]) {
+  const ttl = cacheTtlForResource(resource);
+  return `s-maxage=${ttl}, stale-while-revalidate=${ttl}`;
+}
+
+export async function getCachedCollection(options: CollectionSummaryOptions) {
+  return await getCollectionCached(stableCacheKey(options), options);
+}
+
+export async function getCachedCollectionTokens(options: FetchCollectionTokensOptions) {
+  const normalized = normalizeFetchCollectionTokensOptions(options);
+  return await getCollectionTokensCached(stableCacheKey(normalized), normalized);
+}
+
+export async function getCachedCollectionOrders(options: CollectionOrdersOptions) {
+  return await getCollectionOrdersCached(stableCacheKey(options), options);
+}
+
+export async function getCachedCollectionListings(options: CollectionListingsOptions) {
+  return await getCollectionListingsCached(stableCacheKey(options), options);
+}
+
+export async function getCachedTokenDetail(options: TokenDetailsOptions) {
+  return await getTokenDetailCached(stableCacheKey(options), options);
+}
+
+export async function getCachedCollectionTraitMetadata(options: {
+  address: string;
+  projectId?: string;
+}) {
+  return await getCollectionTraitMetadataCached(stableCacheKey(options), options);
+}
+
+export async function getCachedTokenFees(options: {
+  collection: string;
+  tokenId: string;
+  amount: string;
+}) {
+  return await getTokenFeesCached(stableCacheKey(options), options);
+}


### PR DESCRIPTION
Adds a shared server-side cache layer for marketplace SDK read paths using Next.js unstable_cache, with 1h TTL for trait metadata and 15s TTL for collection/tokens/listings/orders/token detail/fee reads. Introduces internal /api/marketplace/* routes and migrates in-scope hooks plus token fee estimation to those routes while preserving existing behavior. Keeps wallet/portfolio token-balance reads out of scope and unchanged. Includes new cache-policy/key utilities, server read/client helpers, and a detailed PRD/TDD scope doc at docs/SDK-CACHE-PRD-TDD.md. Validation run: npm run lint, npm run typecheck, npm test, npm run build (all passing).