### PR TITLE
fix: resolve mobile token page layout regressions

### DIFF
--- a/src/components/layout/header.test.tsx
+++ b/src/components/layout/header.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Header } from "./header";
@@ -123,9 +123,43 @@ describe("Header", () => {
   it("shows_portfolio_link_for_address_lookup", () => {
     render(<Header />);
 
-    const portfolioLink = screen.getByRole("link", { name: /portfolio/i });
-    expect(portfolioLink).toBeVisible();
-    expect(portfolioLink).toHaveAttribute("href", "/portfolio");
+    const portfolioLinks = screen.getAllByRole("link", { name: /portfolio/i });
+    expect(portfolioLinks.length).toBeGreaterThan(0);
+    expect(portfolioLinks[0]).toHaveAttribute("href", "/portfolio");
+  });
+
+  it("desktop_portfolio_and_connect_controls_are_hidden_on_mobile_breakpoints", () => {
+    render(<Header />);
+
+    const desktopPortfolioLink = screen
+      .getAllByRole("link", { name: /portfolio/i })
+      .find((link) => link.getAttribute("href") === "/portfolio");
+    expect(desktopPortfolioLink).toBeTruthy();
+    expect(desktopPortfolioLink?.className).toContain("hidden");
+    expect(desktopPortfolioLink?.className).toContain("sm:inline-flex");
+
+    const desktopConnectButton = screen
+      .getAllByRole("button", { name: /connect wallet/i })
+      .find((button) => button.className.includes("sm:inline-flex"));
+    expect(desktopConnectButton).toBeTruthy();
+    expect(desktopConnectButton?.className).toContain("hidden");
+  });
+
+  it("mobile_menu_contains_portfolio_and_connect_actions", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    await user.click(screen.getByRole("button", { name: /open menu/i }));
+
+    const mobileMenuDialog = await screen.findByRole("dialog");
+    const mobilePortfolioLink = within(mobileMenuDialog).getByRole("link", {
+      name: /portfolio/i,
+    });
+    expect(mobilePortfolioLink).toHaveAttribute("href", "/portfolio");
+
+    expect(
+      within(mobileMenuDialog).getByRole("button", { name: /connect wallet/i }),
+    ).toBeVisible();
   });
 
   it("login_opens_wallet_modal_with_all_connectors", async () => {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -101,7 +101,7 @@ export function Header() {
         </nav>
 
         {/* Right side actions */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 sm:gap-2">
           {/* Social icons */}
           <div className="hidden sm:flex items-center gap-1 mr-1">
             {SOCIAL_LINKS.map(({ label, href, Icon }) => (
@@ -119,7 +119,7 @@ export function Header() {
           </div>
 
           <CartSidebar />
-          <Button size="sm" variant="ghost" asChild>
+          <Button size="sm" variant="ghost" asChild className="hidden sm:inline-flex">
             <Link href="/portfolio">Portfolio</Link>
           </Button>
 
@@ -152,6 +152,7 @@ export function Header() {
             <Button
               type="button"
               size="sm"
+              className="hidden sm:inline-flex"
               onClick={() => setWalletModalOpen(true)}
               disabled={connectors.length === 0 || isBusy}
             >
@@ -224,6 +225,25 @@ export function Header() {
                     {label}
                   </a>
                 ))}
+                <Link
+                  href="/portfolio"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className="px-2 py-2.5 text-sm text-muted-foreground hover:text-foreground transition-colors rounded-sm hover:bg-muted"
+                >
+                  Portfolio
+                </Link>
+                {!isConnected ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setWalletModalOpen(true);
+                      setMobileMenuOpen(false);
+                    }}
+                    className="px-2 py-2.5 text-left text-sm text-muted-foreground hover:text-foreground transition-colors rounded-sm hover:bg-muted"
+                  >
+                    Connect Wallet
+                  </button>
+                ) : null}
                 {isConnected && address ? (
                   <>
                     <Link

--- a/src/features/token/token-detail-view.test.tsx
+++ b/src/features/token/token-detail-view.test.tsx
@@ -1342,6 +1342,24 @@ describe("token detail view", () => {
     expect(collectionLink).toHaveAttribute("href", "/collections/0xunknown");
   });
 
+  it("breadcrumb_truncates_long_unknown_collection_address", () => {
+    const longUnknownAddress =
+      "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    mockUseTokenDetailQuery.mockReturnValue(
+      successQuery({ token: { token_id: "7", image: null, metadata: { name: "Token #7" } }, orders: [], listings: [] }),
+    );
+
+    render(<TokenDetailView address={longUnknownAddress} tokenId="7" />);
+
+    const truncatedAddress = `${longUnknownAddress.slice(0, 6)}...${longUnknownAddress.slice(-4)}`;
+    const collectionLink = screen.getByRole("link", { name: truncatedAddress });
+    expect(collectionLink).toHaveAttribute(
+      "href",
+      `/collections/${longUnknownAddress}`,
+    );
+    expect(screen.queryByRole("link", { name: longUnknownAddress })).toBeNull();
+  });
+
   it("trait_box_links_to_collection_with_filter", () => {
     mockUseTokenDetailQuery.mockReturnValue(
       successQuery({
@@ -1402,5 +1420,45 @@ describe("token detail view", () => {
     const link = ownerText.closest("a");
     expect(link).not.toBeNull();
     expect(link).toHaveAttribute("href", `/profile/${ownerAddress}`);
+  });
+
+  it("listings_table_uses_mobile_friendly_grid_classes", () => {
+    mockUseCollectionListingsQuery.mockReturnValue(
+      successListingsQuery([
+        {
+          id: 1,
+          tokenId: "1",
+          quantity: 1,
+          currency: "0xstrk",
+          price: "500000000000000000",
+          owner: "0xowner1",
+          expiration: FAR_FUTURE_EXPIRATION,
+        },
+      ]),
+    );
+    mockUseTokenDetailQuery.mockReturnValue(
+      successQuery({
+        token: {
+          token_id: "1",
+          image: "https://cdn.example/1.png",
+          metadata: { name: "Token #1" },
+        },
+        orders: [],
+        listings: [],
+      }),
+    );
+
+    render(<TokenDetailView address="0xabc" tokenId="1" />);
+
+    const tableHeaderRow = screen.getByText(/^Price$/).closest("div");
+    expect(tableHeaderRow).not.toBeNull();
+    expect(tableHeaderRow?.className).toContain("hidden");
+    expect(tableHeaderRow?.className).toContain("sm:grid");
+
+    const ownerCell = screen.getByText("0xowner1");
+    const listingRow = ownerCell.closest("div");
+    expect(listingRow).not.toBeNull();
+    expect(listingRow?.className).toContain("grid-cols-[minmax(0,1fr)_auto]");
+    expect(listingRow?.className).toContain("sm:grid-cols-[1fr_auto_auto_auto]");
   });
 });

--- a/src/features/token/token-detail-view.tsx
+++ b/src/features/token/token-detail-view.tsx
@@ -179,7 +179,9 @@ export function TokenDetailView({
   const { account, address: walletAddress, isConnected } = useAccount();
   const { client } = useMarketplaceClient();
   const { collections, chainLabel } = getMarketplaceRuntimeConfig();
-  const collectionName = collections.find((c) => c.address === address)?.name ?? address;
+  const collectionName =
+    collections.find((c) => c.address === address)?.name ??
+    truncateAddress(address);
   // Human-readable price in STRK (1 STRK = 1e18 wei)
   const [priceInput, setPriceInput] = useState("1");
   const [quantityInput, setQuantityInput] = useState("1");
@@ -464,7 +466,10 @@ export function TokenDetailView({
           </li>
           <li aria-hidden>/</li>
           <li>
-            <Link href={`/collections/${address}`} className="hover:text-foreground transition-colors">
+            <Link
+              href={`/collections/${address}`}
+              className="inline-block max-w-[120px] truncate align-bottom hover:text-foreground transition-colors sm:max-w-[220px]"
+            >
               {collectionName}
             </Link>
           </li>
@@ -621,7 +626,7 @@ export function TokenDetailView({
               ) : null}
             </div>
           ) : cheapestListing ? (
-            <div className="flex items-center justify-between gap-4 rounded-sm border border-border bg-muted/20 px-4 py-3">
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-sm border border-border bg-muted/20 px-4 py-3">
               <div>
                 <p className="text-[10px] uppercase tracking-widest text-muted-foreground mb-0.5">Best price</p>
                 <p className="text-xl font-bold flex items-center gap-1.5">
@@ -725,7 +730,7 @@ export function TokenDetailView({
 
         <div className="flex flex-wrap items-center justify-between gap-2">
           <h2 className="text-sm font-medium tracking-widest uppercase text-muted-foreground">Listings</h2>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               disabled={!cheapestListing || isOwnCheapest}
               onClick={() => {
@@ -859,7 +864,7 @@ export function TokenDetailView({
         ) : (
           <div className="rounded border border-border overflow-hidden">
             {/* Table header */}
-            <div className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-x-4 px-3 py-2 bg-muted/40 border-b border-border">
+            <div className="hidden grid-cols-[1fr_auto_auto_auto] items-center gap-x-4 border-b border-border bg-muted/40 px-3 py-2 sm:grid">
               <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Price</span>
               <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Seller</span>
               <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Expires</span>
@@ -879,9 +884,9 @@ export function TokenDetailView({
               return (
                 <div
                   key={listing.id}
-                  className="grid grid-cols-[1fr_auto_auto_auto] items-center gap-x-4 px-3 py-2.5 border-b border-border/50 last:border-b-0 hover:bg-muted/20 transition-colors"
+                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 border-b border-border/50 px-3 py-2.5 transition-colors last:border-b-0 hover:bg-muted/20 sm:grid-cols-[1fr_auto_auto_auto] sm:gap-x-4 sm:gap-y-0"
                 >
-                  <div className="flex items-center gap-2 min-w-0">
+                  <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-2">
                     <span className="text-sm font-medium text-primary font-mono flex items-center gap-1.5">
                       {formatPriceForDisplay(listing.price) ?? String(listing.price)}
                       {listing.currency ? (
@@ -896,15 +901,20 @@ export function TokenDetailView({
                   </div>
                   <Link
                     href={`/profile/${listing.owner}`}
-                    className="text-xs text-muted-foreground hover:text-foreground hover:underline font-mono transition-colors"
+                    className="col-start-1 row-start-2 max-w-[11rem] truncate text-xs text-muted-foreground font-mono transition-colors hover:text-foreground hover:underline sm:col-auto sm:row-auto sm:max-w-none"
                   >
                     {isOwnRow ? "You" : truncateAddress(listing.owner)}
                   </Link>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="col-start-2 row-start-2 text-right text-xs text-muted-foreground sm:col-auto sm:row-auto sm:text-left">
                     {expiration ? formatRelativeExpiry(expiration) : "—"}
                   </span>
                   {isOwnRow ? (
-                    <Badge variant="outline" className="text-[10px] px-2 py-0.5">Your listing</Badge>
+                    <Badge
+                      variant="outline"
+                      className="col-start-2 row-start-1 justify-self-end px-2 py-0.5 text-[10px] sm:col-auto sm:row-auto"
+                    >
+                      Your listing
+                    </Badge>
                   ) : (
                     <Button
                       disabled={!hasFullCartData}
@@ -922,6 +932,7 @@ export function TokenDetailView({
                       size="sm"
                       type="button"
                       variant={isRowAdded ? "default" : "outline"}
+                      className="col-start-2 row-start-1 h-7 justify-self-end px-2 text-xs sm:col-auto sm:row-auto sm:h-8 sm:px-3 sm:text-sm"
                     >
                       {isRowAdded ? "Added" : "Add to cart"}
                     </Button>


### PR DESCRIPTION
Fixes mobile breakage on token ID pages by reducing header action crowding, truncating unknown-collection breadcrumb addresses, and making listings rows mobile-first. Desktop-only header controls (Portfolio and Connect Wallet) are hidden on small breakpoints while equivalent actions are available in the mobile sheet menu. Listings now use a two-column mobile grid so price content does not collapse, with the existing desktop table preserved at sm+ breakpoints. Validation: pnpm test src/components/layout/header.test.tsx src/features/token/token-detail-view.test.tsx, pnpm typecheck, pnpm build, and pnpm lint (reports 4 pre-existing warnings in src/features/cart/components/cart-sidebar.tsx).