### PR TITLE
feat(collections): add edge caching for SEO data and OG image routes

### DIFF
--- a/src/app/collections/[address]/[tokenId]/opengraph-image.tsx
+++ b/src/app/collections/[address]/[tokenId]/opengraph-image.tsx
@@ -7,6 +7,10 @@ export const size = {
 
 export const contentType = "image/png";
 
+// Cache OG images at the edge for 60 seconds; revalidate in background.
+// Matches the token SEO data cache TTL in seo-data.ts.
+export const revalidate = 60;
+
 export default async function Image({
   params,
 }: {

--- a/src/app/collections/[address]/opengraph-image.tsx
+++ b/src/app/collections/[address]/opengraph-image.tsx
@@ -7,6 +7,10 @@ export const size = {
 
 export const contentType = "image/png";
 
+// Cache OG images at the edge for 5 minutes; revalidate in background for 15 minutes.
+// Matches the collection SEO data cache TTL in seo-data.ts.
+export const revalidate = 300;
+
 export default async function Image({
   params,
 }: {

--- a/src/lib/marketplace/seo-data.ts
+++ b/src/lib/marketplace/seo-data.ts
@@ -1,6 +1,10 @@
 import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import { getMarketplaceRuntimeConfig } from "@/lib/marketplace/config";
 import { tokenImage, tokenName } from "@/lib/marketplace/token-display";
+
+const COLLECTION_CACHE_REVALIDATE_SECONDS = 300;
+const TOKEN_CACHE_REVALIDATE_SECONDS = 60;
 
 type TokenLike = {
   token_id?: unknown;
@@ -161,7 +165,7 @@ const getMarketplaceClient = cache(async (): Promise<MarketplaceClientLike | nul
   }
 });
 
-async function fetchCollection(address: string) {
+async function _fetchCollectionUncached(address: string) {
   const context = resolveCollectionContext(address);
   const client = await getMarketplaceClient();
 
@@ -191,7 +195,16 @@ async function fetchCollection(address: string) {
   }
 }
 
-async function fetchTokenWithFallback(options: {
+const fetchCollectionCached = unstable_cache(
+  _fetchCollectionUncached,
+  ["seo-collection"],
+  { revalidate: COLLECTION_CACHE_REVALIDATE_SECONDS },
+);
+
+// Per-request dedup on top of the cross-request edge cache.
+const fetchCollection = cache((address: string) => fetchCollectionCached(address));
+
+async function _fetchTokenWithFallbackUncached(options: {
   collection: string;
   tokenId: string;
   projectId?: string;
@@ -236,6 +249,19 @@ async function fetchTokenWithFallback(options: {
     return null;
   }
 }
+
+const fetchTokenWithFallbackCached = unstable_cache(
+  (collection: string, tokenId: string, projectId?: string) =>
+    _fetchTokenWithFallbackUncached({ collection, tokenId, projectId }),
+  ["seo-token"],
+  { revalidate: TOKEN_CACHE_REVALIDATE_SECONDS },
+);
+
+// Per-request dedup on top of the cross-request edge cache.
+const fetchTokenWithFallback = cache(
+  (options: { collection: string; tokenId: string; projectId?: string }) =>
+    fetchTokenWithFallbackCached(options.collection, options.tokenId, options.projectId),
+);
 
 function normalizedTokenImage(token: TokenLike) {
   return normalizeImageUrl(tokenImage(token as never));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,18 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterAll, afterEach, beforeAll } from "vitest";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { server } from "@/test/msw/server";
+
+// next/cache is not available outside the Next.js runtime (e.g. Vitest / jsdom).
+// Replace unstable_cache with a pass-through so tests exercise the underlying
+// fetch logic without requiring the incremental cache context.
+vi.mock("next/cache", () => ({
+  unstable_cache: <T extends (...args: unknown[]) => Promise<unknown>>(
+    fn: T,
+  ) => fn,
+  revalidateTag: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
 
 beforeAll(() => {
   if (!HTMLElement.prototype.hasPointerCapture) {


### PR DESCRIPTION
## What changed

Adds edge caching for collection and token SEO data fetched server-side during `generateMetadata` and OG image generation.

## Why

Collection and token SEO data is fetched on every request but changes infrequently. Without caching, every social share / link preview triggers a fresh SDK call to Cartridge. This adds meaningful latency and unnecessary load.

## Changes

**`src/lib/marketplace/seo-data.ts`**
- Wrapped `fetchCollection` with `unstable_cache` (5min TTL) + React `cache` for per-request dedup
- Wrapped `fetchTokenWithFallback` with `unstable_cache` (60s TTL) + React `cache` for per-request dedup
- Follows the existing `EDGE_CACHE_CONTROL` pattern from `trait-metadata/route.ts`
- TTLs tuned: collections change slowly (5min), token listings change faster (60s)

**`src/app/collections/[address]/opengraph-image.tsx`**
- Added `export const revalidate = 300` to cache OG images at the edge (matches collection TTL)

**`src/app/collections/[address]/[tokenId]/opengraph-image.tsx`**
- Added `export const revalidate = 60` to cache token OG images at the edge (matches token TTL)

**`src/test/setup.ts`**
- Added `vi.mock("next/cache")` so `unstable_cache` passes through as identity in Vitest (no incremental cache context available in jsdom)

## Risk / Impact

- Low risk: caching is additive, not structural. Fallback paths unchanged.
- SEO metadata may be up to 5min stale after a collection update — acceptable tradeoff.
- Token OG images may be 60s stale — acceptable for link previews.

## Test evidence

```
pnpm typecheck  → clean
pnpm lint       → 0 errors, 5 pre-existing warnings (not introduced by this PR)
pnpm test       → 395 passed (42 test files)
```