### PR TITLE
feat(collections): add dense and list token views

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,108 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+}

--- a/src/features/collections/collection-token-grid.test.tsx
+++ b/src/features/collections/collection-token-grid.test.tsx
@@ -551,8 +551,10 @@ describe("collection token grid", () => {
     render(<CollectionTokenGrid address="0xabc" projectId="project-a" />);
 
     expect(screen.getByRole("button", { name: /compact/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: /dense/i })).toBeVisible();
     expect(screen.getByRole("button", { name: /standard/i })).toBeVisible();
     expect(screen.getByRole("button", { name: /comfort/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: /list/i })).toBeVisible();
     expect(screen.getByTestId("collection-token-grid-cards")).toHaveClass(
       "grid-cols-1",
       "sm:grid-cols-2",
@@ -584,8 +586,48 @@ describe("collection token grid", () => {
     await user.click(screen.getByRole("button", { name: /compact/i }));
     expect(grid).toHaveClass("grid-cols-2", "sm:grid-cols-3", "lg:grid-cols-4");
 
+    await user.click(screen.getByRole("button", { name: /dense/i }));
+    expect(grid).toHaveClass("grid-cols-2", "sm:grid-cols-3", "lg:grid-cols-6");
+
     await user.click(screen.getByRole("button", { name: /comfort/i }));
     expect(grid).toHaveClass("grid-cols-1", "sm:grid-cols-1", "lg:grid-cols-2");
+  });
+
+  it("list_view_renders_tokens_in_a_table_layout", async () => {
+    mockUseCollectionTokensQuery.mockReturnValue({
+      data: {
+        page: {
+          tokens: [token("1")],
+          nextCursor: null,
+        },
+        error: null,
+      },
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+    mockUseCollectionListingsQuery.mockReturnValue(
+      successListingsResult([
+        { id: 21, tokenId: 1, price: 200, currency: "0xfee", quantity: 1 },
+      ]),
+    );
+
+    const user = userEvent.setup();
+    render(<CollectionTokenGrid address="0xabc" projectId="project-a" />);
+
+    await user.click(screen.getByRole("button", { name: /list/i }));
+
+    const table = screen.getByTestId("collection-token-grid-table");
+    expect(table).toBeVisible();
+    expect(screen.queryByTestId("collection-token-grid-cards")).toBeNull();
+    expect(screen.getByRole("link", { name: /token #1/i })).toHaveAttribute(
+      "href",
+      "/collections/0xabc/1",
+    );
+    expect(screen.getByText("200")).toBeVisible();
   });
 
   it("tokens_reset_when_address_prop_changes", async () => {

--- a/src/features/collections/collection-token-grid.tsx
+++ b/src/features/collections/collection-token-grid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useReducer, useState } from "react";
 import type { NormalizedToken } from "@cartridge/arcade/marketplace";
 import {
@@ -7,9 +8,11 @@ import {
   useCollectionTokensQuery,
 } from "@/lib/marketplace/hooks";
 import {
+  formatPriceForDisplay,
   displayTokenId,
   listingPriceByTokenId,
   tokenId,
+  tokenName,
   tokenPrice,
 } from "@/lib/marketplace/token-display";
 
@@ -34,6 +37,15 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { MarketplaceTokenCard } from "@/components/marketplace/token-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TokenSymbol } from "@/components/ui/token-symbol";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import type { ActiveFilters } from "@/lib/marketplace/traits";
 import { COLLECTION_LISTING_SAMPLE_LIMIT } from "@/lib/marketplace/query-limits";
 import { cn } from "@/lib/utils";
@@ -55,10 +67,12 @@ type CollectionTokenGridProps = {
   sweepPreviewTokenIds?: Set<string>;
 };
 
-type GridDensityMode = "compact" | "standard" | "comfort";
+type GridDensityMode = "compact" | "dense" | "standard" | "comfort";
+type GridLayoutMode = GridDensityMode | "list";
 
 const GRID_CLASSES_BY_DENSITY: Record<GridDensityMode, string> = {
   compact: "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4",
+  dense: "grid-cols-2 sm:grid-cols-3 lg:grid-cols-6",
   standard: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
   comfort: "grid-cols-1 sm:grid-cols-1 lg:grid-cols-2",
 };
@@ -180,7 +194,7 @@ export function CollectionTokenGrid({
   sweepPreviewTokenIds,
 }: CollectionTokenGridProps) {
   const { addListingToCart, isRecentlyAdded } = useAddToCartFeedback();
-  const [gridDensity, setGridDensity] = useState<GridDensityMode>("standard");
+  const [gridMode, setGridMode] = useState<GridLayoutMode>("standard");
   const tokenIdsKey = useMemo(() => tokenIds?.join(",") ?? "", [tokenIds]);
   const activeFiltersKey = useMemo(
     () =>
@@ -270,40 +284,61 @@ export function CollectionTokenGrid({
     () => sortTokens(visibleTokens, sortMode, listingPrices, listingPriceMap),
     [listingPriceMap, listingPrices, sortMode, visibleTokens],
   );
-  const gridClasses = GRID_CLASSES_BY_DENSITY[gridDensity];
+  const isListMode = gridMode === "list";
+  const gridClasses = GRID_CLASSES_BY_DENSITY[isListMode ? "standard" : gridMode];
 
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-end gap-1">
         <Button
-          aria-pressed={gridDensity === "compact"}
-          onClick={() => setGridDensity("compact")}
+          aria-pressed={gridMode === "compact"}
+          onClick={() => setGridMode("compact")}
           size="sm"
           type="button"
-          variant={gridDensity === "compact" ? "default" : "outline"}
+          variant={gridMode === "compact" ? "default" : "outline"}
           className="h-7 px-2 text-xs"
         >
           Compact
         </Button>
         <Button
-          aria-pressed={gridDensity === "standard"}
-          onClick={() => setGridDensity("standard")}
+          aria-pressed={gridMode === "dense"}
+          onClick={() => setGridMode("dense")}
           size="sm"
           type="button"
-          variant={gridDensity === "standard" ? "default" : "outline"}
+          variant={gridMode === "dense" ? "default" : "outline"}
+          className="h-7 px-2 text-xs"
+        >
+          Dense
+        </Button>
+        <Button
+          aria-pressed={gridMode === "standard"}
+          onClick={() => setGridMode("standard")}
+          size="sm"
+          type="button"
+          variant={gridMode === "standard" ? "default" : "outline"}
           className="h-7 px-2 text-xs"
         >
           Standard
         </Button>
         <Button
-          aria-pressed={gridDensity === "comfort"}
-          onClick={() => setGridDensity("comfort")}
+          aria-pressed={gridMode === "comfort"}
+          onClick={() => setGridMode("comfort")}
           size="sm"
           type="button"
-          variant={gridDensity === "comfort" ? "default" : "outline"}
+          variant={gridMode === "comfort" ? "default" : "outline"}
           className="h-7 px-2 text-xs"
         >
           Comfort
+        </Button>
+        <Button
+          aria-pressed={gridMode === "list"}
+          onClick={() => setGridMode("list")}
+          size="sm"
+          type="button"
+          variant={gridMode === "list" ? "default" : "outline"}
+          className="h-7 px-2 text-xs"
+        >
+          List
         </Button>
       </div>
 
@@ -328,7 +363,7 @@ export function CollectionTokenGrid({
         </Card>
       ) : null}
 
-      {!tokenQuery.isLoading ? (
+      {!tokenQuery.isLoading && !isListMode ? (
         <div
           className={cn("grid gap-3", gridClasses)}
           data-testid="collection-token-grid-cards"
@@ -388,6 +423,91 @@ export function CollectionTokenGrid({
             );
           })}
         </div>
+      ) : null}
+
+      {!tokenQuery.isLoading && isListMode ? (
+        <Card className="py-0">
+          <CardContent className="p-0">
+            <Table data-testid="collection-token-grid-table">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Token</TableHead>
+                  <TableHead>Price</TableHead>
+                  <TableHead className="text-right">Action</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedTokens.map((token) => {
+                  const tokenKey = displayTokenId(token);
+                  const cheapestListing = listingPrices.get(tokenKey);
+                  const isAdded = isRecentlyAdded(cheapestListing?.orderId);
+                  const isSweepPreview = sweepPreviewTokenIds?.has(tokenKey) ?? false;
+                  const price =
+                    cheapestListing?.price ??
+                    listingPriceMap.get(tokenKey) ??
+                    tokenPrice(token);
+                  const displayPrice = formatPriceForDisplay(price);
+
+                  return (
+                    <TableRow key={tokenId(token)} className={cn(isSweepPreview && "bg-muted/60")}>
+                      <TableCell>
+                        <div className="space-y-0.5">
+                          <Link
+                            href={`/collections/${address}/${tokenId(token)}`}
+                            className="text-sm font-medium hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                          >
+                            {tokenName(token)}
+                          </Link>
+                          <p className="text-xs text-muted-foreground">#{tokenKey}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {displayPrice ? (
+                          <p className="text-xs text-primary font-medium flex items-center gap-1">
+                            {displayPrice}
+                            {cheapestListing?.currency ? (
+                              <TokenSymbol
+                                address={cheapestListing.currency}
+                                className="text-muted-foreground"
+                              />
+                            ) : null}
+                          </p>
+                        ) : (
+                          <p className="text-xs text-muted-foreground">Not listed</p>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          disabled={!cheapestListing || isSweepPreview}
+                          onClick={() => {
+                            if (!cheapestListing) {
+                              return;
+                            }
+
+                            addListingToCart(
+                              cartItemFromTokenListing(
+                                token,
+                                address,
+                                cheapestListing,
+                                projectId,
+                              ),
+                            );
+                          }}
+                          size="sm"
+                          type="button"
+                          variant={isAdded ? "default" : isSweepPreview ? "secondary" : "outline"}
+                          className="w-full sm:w-auto"
+                        >
+                          {isAdded ? "Added" : isSweepPreview ? "Pending sweep" : "Add to cart"}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
       ) : null}
 
       {tokenQuery.isSuccess && visibleTokens.length === 0 ? (


### PR DESCRIPTION
This PR adds two new collection token presentations: a Dense card mode (6 cards per row on large screens) and a List table view with token, price, and action columns. It also introduces a shared shadcn-style table primitive at src/components/ui/table.tsx and reuses existing add-to-cart behavior for both grid and list rows. Tests were updated first to cover the new controls and layouts, and implementation was then added to satisfy those cases while preserving existing sorting, pagination, and sweep-preview behavior. Validation run: pnpm test src/features/collections/collection-token-grid.test.tsx; pnpm test; pnpm typecheck; pnpm lint; pnpm build; pnpm test:e2e.