### PR TITLE
Improve collection filter load performance

### DIFF
--- a/docs/TDD-PRD-collection-filter-performance.md
+++ b/docs/TDD-PRD-collection-filter-performance.md
@@ -1,0 +1,556 @@
+# Collection Filter Performance TDD PRD
+
+Version: 1.0  
+Date: March 18, 2026  
+Status: Draft for execution  
+Primary focus: Fast first filter paint, responsive trait interactions, preserved URL-canonical discovery state
+
+## 1. Product Intent
+
+Improve perceived and measured performance on `/collections/[address]` so trait filters feel immediate on initial load and during interaction, without weakening current marketplace behavior:
+
+1. Preserve multi-collection routing and URL-canonical filter state.
+2. Preserve lazy trait-value loading and active-filter-aware counts.
+3. Reduce time until users can see and use the filter sidebar.
+4. Avoid loading unrelated collection-grid work on the critical path for filter paint.
+
+## 2. Problem Statement
+
+The collection page currently feels slow because the trait sidebar is blocked on client-side boot and separate network requests, while the route also performs additional token-grid work that competes for bandwidth and render time.
+
+Observed causes from code inspection:
+
+1. Filter metadata is client-fetched after hydration.
+   - `src/app/collections/[address]/page.tsx` only resolves the address and renders a client container.
+   - `src/features/collections/collection-route-view.tsx` starts `useTraitNamesSummaryQuery` on the client.
+2. Trait values require a second request when a user opens a trait group.
+   - `useTraitValuesQuery` is keyed by `traitName` and other active filters, so open groups refetch as filters change.
+3. The grid performs additional sequential work unrelated to first filter paint.
+   - `collection-token-grid` fetches listings, derives token ids, then fetches those tokens in a second query.
+4. Each filter toggle performs route-state churn.
+   - `router.push` happens for every change, resetting grid state and query keys.
+
+The slow experience is primarily a query and rendering-path problem, not a trait-option computation problem.
+
+## 3. Goals and Success Metrics
+
+## 3.1 Product Goals
+
+1. Make the filter sidebar visibly useful on first paint.
+2. Keep trait interactions responsive under active filtering.
+3. Preserve exact filter URL behavior across refresh and share-link flows.
+4. Reduce the amount of unrelated work on the route’s critical path.
+
+## 3.2 Performance KPIs
+
+1. First filter paint:
+   - Definition: time from navigation start to first rendered trait list with real trait names.
+   - Target: p50 <= 1.2s on local benchmark fixtures, p95 <= 2.0s.
+2. Trait open latency:
+   - Definition: time from expanding a trait group to visible values or loading skeleton.
+   - Target: feedback <= 150ms, resolved values p50 <= 800ms.
+3. Filter apply responsiveness:
+   - Definition: time from selecting a trait value to visible pending UI and updated URL.
+   - Target: pending UI <= 100ms, URL sync <= 250ms.
+4. Main-thread stability:
+   - Definition: no long task > 200ms caused by sort/filter render work on benchmark collections during first interaction.
+   - Target: zero benchmark runs with route-blocking long task above threshold.
+
+## 3.3 Guardrails
+
+1. No regression to URL-canonical `trait` and `sort` state.
+2. No regression to active-filter-aware trait counts.
+3. No regression to cart/add-to-cart behavior from collection grid.
+4. No release with failing unit, integration, e2e, typecheck, or lint checks.
+
+## 4. Current Baseline
+
+Current route behavior:
+
+1. The route shell is server-rendered but does not prefetch filter data.
+2. Trait names are fetched via `useTraitNamesSummaryQuery` on the client.
+3. Trait values are fetched lazily for the currently open trait only.
+4. The route mounts token, listing, and trait queries together in the same client tree.
+5. Grid enrichment performs a listings -> token ids -> tokens waterfall.
+6. Filter changes push new search params immediately for every interaction.
+
+Known positive behavior to retain:
+
+1. Trait value requests are lazy rather than eager N+1 on initial render.
+2. Query client already applies a 60 second stale time and disables refetch-on-focus.
+3. Trait parsing and precomputed filter generation are deterministic and already tested.
+
+## 5. Scope
+
+## 5.1 In Scope
+
+1. `/collections/[address]` route performance for filter sidebar loading and interaction.
+2. Server/client data-fetching boundary for trait summaries.
+3. Cache strategy for collection trait summaries.
+4. Query isolation so filter paint is not blocked by grid enrichment work.
+5. URL update ergonomics for rapid filter interactions.
+6. Benchmarking and instrumentation for first filter paint and interaction latency.
+
+## 5.2 Out of Scope
+
+1. New discovery features unrelated to performance.
+2. Redesign of collection filter UX or visual language.
+3. New backend indexing systems.
+4. Changes to cart, checkout, or token detail behavior except where required to prevent regression.
+
+## 6. Users and Core Jobs
+
+1. Collector:
+   - Open a collection and immediately understand the available trait filters.
+   - Narrow token results without waiting through heavy page recomputation.
+2. Trader:
+   - Change filters rapidly while comparing listed inventory.
+3. Operator:
+   - Measure whether collection performance improved and remained stable across releases.
+
+## 7. Root Cause Summary
+
+## 7.1 Primary Cause: Client-only Filter Metadata Fetch
+
+Trait names are not prefetched on the server. The first meaningful sidebar render waits on:
+
+1. client hydration
+2. query startup
+3. Arcade import/query execution
+4. network response
+
+This produces a slow empty sidebar even when the route shell is already visible.
+
+## 7.2 Secondary Cause: Unrelated Waterfall on the Same Route
+
+The collection grid starts work that is not required to make filters usable:
+
+1. listings fetch
+2. derive listed token ids
+3. token fetch for those ids
+
+This increases contention and can delay interactive work on large collections.
+
+## 7.3 Tertiary Cause: High Churn During Filter Changes
+
+Each toggle updates URL state immediately, which causes:
+
+1. route-state churn
+2. query-key churn
+3. grid reset work
+4. refetch of open trait values when other active filters change
+
+## 8. Proposed Solution
+
+## 8.1 Primary Architecture Change
+
+Move trait summary loading to the server route boundary and hydrate the result into the client tree before the sidebar mounts.
+
+Implementation direction:
+
+1. In `src/app/collections/[address]/page.tsx`, prefetch collection essentials and trait summary in parallel.
+2. Hydrate the query cache or pass typed server-fetched data into the collection route view.
+3. Render the filter sidebar from prefetched summary data on first paint.
+4. Keep trait-value requests lazy per open trait group.
+
+## 8.2 Critical Path Isolation
+
+Decouple filter paint from grid enrichment work.
+
+Implementation direction:
+
+1. Split the filter sidebar and token grid into separate suspense or loading boundaries.
+2. Defer listed-token enrichment until after first grid paint or only when required by the current tab/sort.
+3. Ensure the sidebar does not wait for listings-derived token work.
+
+## 8.3 Interaction Smoothing
+
+Reduce churn from per-click routing work.
+
+Implementation direction:
+
+1. Wrap URL updates in transitions.
+2. Prefer `router.replace` for rapid in-page filter changes unless history behavior explicitly requires `push`.
+3. Batch related filter changes where feasible.
+4. Preserve optimistic local state so checkboxes/pills respond immediately.
+
+## 8.4 Cache Strategy
+
+Trait summaries should be cached by collection address and project id because they are reused often and change much less frequently than token-grid state.
+
+Implementation direction:
+
+1. Add server-side request deduplication for trait summary fetches.
+2. Add short-lived cache semantics appropriate for collection metadata freshness.
+3. Keep client query stale behavior aligned with server caching to avoid thrash.
+
+## 9. Functional Requirements
+
+## FR-PERF-01 First Filter Paint
+
+Requirements:
+
+1. The route must render trait names without waiting for a client-only trait-summary fetch.
+2. The sidebar must show a stable loading skeleton only when prefetched data is unavailable.
+3. The route must preserve existing empty and error states for missing trait metadata.
+
+Acceptance criteria:
+
+1. Trait names are available on first meaningful render for benchmark collections with valid trait metadata.
+2. Refreshing the page does not revert to a long empty “Loading traits...” state when cached summary data is available.
+3. Missing trait metadata still shows a non-blocking fallback state.
+
+Tests required:
+
+1. Unit: server prefetch helper builds the expected query payload and cache key.
+2. Integration: route renders prefetched trait names without waiting for client query resolution.
+3. E2E: hard-refresh collection page and verify trait names appear before token-grid enrichment completes.
+
+## FR-PERF-02 Trait Interaction Responsiveness
+
+Requirements:
+
+1. Expanding a trait group must provide immediate feedback.
+2. Selecting a trait value must update local UI immediately and preserve canonical URL state.
+3. Open trait groups may refetch counts, but feedback must not block input.
+
+Acceptance criteria:
+
+1. Expanding a trait group shows either values or a loading placeholder within 150ms.
+2. Selecting a filter updates the selected state before the grid finishes reloading.
+3. URL state remains shareable and equivalent after refresh.
+
+Tests required:
+
+1. Unit: route-state update helper distinguishes replace-vs-push semantics.
+2. Integration: toggle trait selection and assert immediate active state plus eventual URL sync.
+3. E2E: apply multiple trait filters rapidly and verify no lost selections or stale URL state.
+
+## FR-PERF-03 Critical Path Isolation
+
+Requirements:
+
+1. The filter sidebar must not depend on listings-derived token enrichment.
+2. Grid enrichment work must be deferred or isolated from first filter paint.
+3. Loading states for sidebar and grid must remain independent.
+
+Acceptance criteria:
+
+1. The sidebar can render usable filter data while the grid is still loading.
+2. Listed-token enrichment no longer blocks first filter paint.
+3. Error/loading in grid enrichment does not collapse the filter sidebar.
+
+Tests required:
+
+1. Unit: listed-token enrichment selector skips work when not required.
+2. Integration: sidebar remains interactive while deferred grid enrichment is pending.
+3. E2E: benchmark collection route still exposes filters when listings-derived token work is artificially delayed.
+
+## FR-PERF-04 Observability and Regression Protection
+
+Requirements:
+
+1. The route must record benchmarkable measurements for filter paint and filter apply latency.
+2. Performance regressions must be catchable in CI or pre-merge scripts.
+3. The benchmark harness output must be deterministic and reviewable.
+
+Acceptance criteria:
+
+1. A repeatable benchmark script reports p50/p95 for first filter paint and filter apply.
+2. Regression thresholds are documented and enforced in engineering workflow.
+3. Performance evidence can be attached to PRs affecting collection performance.
+
+Tests required:
+
+1. Unit: benchmark report includes new filter-paint and interaction targets.
+2. Integration: instrumentation events fire with expected route and collection identifiers.
+3. E2E: benchmark scenario can be executed against a local fixture or mocked environment.
+
+## 10. Technical Design Constraints
+
+1. UI must continue using `shadcn/ui` primitives and Tailwind tokens only.
+2. Business logic belongs in `src/lib` or `src/features`, not route files beyond route orchestration.
+3. Strong typing is required across prefetch, hydration, cache, and benchmark code.
+4. Changes must be test-first for behavior and performance-sensitive logic.
+
+## 11. Delivery Plan (TDD)
+
+## Phase 0: Baseline and Measurement
+
+Goal:
+Establish a trustworthy performance baseline before behavior changes.
+
+### PERF-001: Benchmark Harness Extension
+
+Outcome:
+Capture first filter paint and filter apply metrics in a repeatable schema.
+
+RED tests to write first:
+
+1. unit test for benchmark report schema covering filter-specific targets
+2. unit test for percentile handling with partial failures and empty samples
+
+GREEN implementation tasks:
+
+1. extend `src/lib/marketplace/performance-harness.ts` for filter targets
+2. add benchmark target names and report formatting for collection filter performance
+
+REFACTOR tasks:
+
+1. extract shared benchmark target factories
+2. keep naming stable for future CI reporting
+
+Evidence required in PR:
+
+1. `pnpm test -- performance-harness`
+2. sample benchmark report artifact
+
+Estimate: 2
+
+### PERF-002: Route Performance Instrumentation
+
+Outcome:
+Track trait-summary ready, first filter paint, and filter-apply milestones.
+
+RED tests to write first:
+
+1. integration test for instrumentation callback/event payload on prefetched render
+2. integration test for filter-apply event timing boundaries
+
+GREEN implementation tasks:
+
+1. add lightweight performance markers in collection route feature code
+2. expose route and collection metadata in event payloads
+
+REFACTOR tasks:
+
+1. centralize instrumentation constants and payload typing
+
+Evidence required in PR:
+
+1. test output for instrumentation module
+2. example captured timings from local run
+
+Estimate: 3
+
+## Phase 1: First Filter Paint
+
+Goal:
+Make trait names available at first meaningful render.
+
+### PERF-010: Server Trait Summary Prefetch
+
+Outcome:
+Collection route prefetched with trait summary and collection essentials in parallel.
+
+RED tests to write first:
+
+1. unit test for server prefetch helper cache key and argument normalization
+2. integration test for hydrated route rendering trait names without client fetch delay
+3. integration test for empty/error fallback when prefetch fails
+
+GREEN implementation tasks:
+
+1. add server-side prefetch helper for trait summary
+2. fetch collection essentials and trait summary in parallel from the route boundary
+3. hydrate or pass prefetched data into the client collection module
+
+REFACTOR tasks:
+
+1. reduce duplication between client query key factories and server prefetch code
+2. extract typed route preload module under `src/features/collections` or `src/lib/marketplace`
+
+Evidence required in PR:
+
+1. `pnpm test`
+2. screenshot or video of first filter paint before/after
+
+Estimate: 5
+
+### PERF-011: Trait Summary Cache Policy
+
+Outcome:
+Repeated collection visits reuse summary data instead of refetching immediately.
+
+RED tests to write first:
+
+1. unit test for cache deduplication per collection address/project id
+2. integration test for repeated route render reusing cached summary data
+
+GREEN implementation tasks:
+
+1. introduce request deduplication and short-lived cache semantics
+2. align cache freshness with client query configuration
+
+REFACTOR tasks:
+
+1. document cache contract in code and docs
+
+Evidence required in PR:
+
+1. tests demonstrating stable cache reuse
+2. benchmark showing improved repeat navigation performance
+
+Estimate: 3
+
+## Phase 2: Critical Path Isolation
+
+Goal:
+Keep filters usable even when grid-related work is still loading.
+
+### PERF-020: Separate Sidebar and Grid Loading Boundaries
+
+Outcome:
+Sidebar render no longer waits on grid enrichment work.
+
+RED tests to write first:
+
+1. integration test proving sidebar renders while grid remains pending
+2. integration test proving grid error/loading does not hide filters
+
+GREEN implementation tasks:
+
+1. split sidebar and grid into isolated loading boundaries
+2. keep route-level loading and error messaging explicit per panel
+
+REFACTOR tasks:
+
+1. simplify collection route view composition to avoid cross-coupled loading state
+
+Evidence required in PR:
+
+1. integration test output
+2. screenshots of independent loading states
+
+Estimate: 5
+
+### PERF-021: Defer Listed-Token Enrichment
+
+Outcome:
+Listings-derived token waterfall removed from the initial filter critical path.
+
+RED tests to write first:
+
+1. unit test for enrichment trigger conditions
+2. integration test proving first filter paint does not await listed-token enrichment
+3. integration test preserving listed-token behavior when enrichment eventually runs
+
+GREEN implementation tasks:
+
+1. defer or gate listed-token enrichment until needed
+2. preserve grid correctness and listed-token display behavior
+
+REFACTOR tasks:
+
+1. extract enrichment decision logic from the grid component
+
+Evidence required in PR:
+
+1. targeted test output
+2. benchmark comparison showing reduced initial route latency
+
+Estimate: 5
+
+## Phase 3: Interaction Smoothing
+
+Goal:
+Reduce route churn while preserving canonical URL state.
+
+### PERF-030: Transitioned Filter URL Updates
+
+Outcome:
+Filter toggles feel immediate and do not block input.
+
+RED tests to write first:
+
+1. integration test for optimistic selection state during pending navigation
+2. integration test for canonical URL output after rapid filter changes
+
+GREEN implementation tasks:
+
+1. move filter URL updates into transitions
+2. evaluate `replace` for rapid filter changes where history fidelity is not required
+3. preserve refresh/share-link semantics
+
+REFACTOR tasks:
+
+1. extract reusable filter navigation helper
+
+Evidence required in PR:
+
+1. `pnpm test`
+2. manual verification notes for back/forward behavior
+
+Estimate: 3
+
+### PERF-031: Open Trait Refetch Ergonomics
+
+Outcome:
+Open trait group refetches remain accurate without jarring UX.
+
+RED tests to write first:
+
+1. integration test for open trait group staying visually stable while counts refetch
+2. integration test for no lost active state during rapid changes
+
+GREEN implementation tasks:
+
+1. improve pending-state presentation for open trait groups
+2. avoid unnecessary visual resets while values reload
+
+REFACTOR tasks:
+
+1. isolate trait-panel pending state logic from raw query objects
+
+Evidence required in PR:
+
+1. interaction capture for rapid filter toggling
+
+Estimate: 3
+
+## 12. Test Plan and Coverage Matrix
+
+| Area | Unit | Integration | E2E |
+| --- | --- | --- | --- |
+| Server prefetch | cache key + payload | hydrated first render | refresh route -> filters visible |
+| Trait summary cache | dedupe policy | repeat visit reuse | repeat navigation smoke |
+| Sidebar/grid isolation | enrichment gating | independent loading states | delayed grid still shows filters |
+| Filter URL updates | canonical params | optimistic UI + URL sync | rapid multi-filter apply |
+| Trait refetch ergonomics | pending-state helpers | open group stability | rapid change stability |
+| Benchmarking | report schema | instrumentation payloads | benchmark route flow |
+
+## 13. Risks and Mitigations
+
+1. Server-prefetch mismatch with client query keys:
+   - Mitigation: share typed key factories and fixture-backed integration tests.
+2. Stale trait metadata from aggressive caching:
+   - Mitigation: short cache windows and explicit cache invalidation contract.
+3. History/back-button behavior regressions from `replace`:
+   - Mitigation: preserve documented semantics and add e2e coverage.
+4. Hidden dependency between grid enrichment and sidebar state:
+   - Mitigation: isolate panel state and add delayed-grid integration tests.
+
+## 14. Rollout and Evidence
+
+Each implementation PR should include:
+
+1. before/after benchmark numbers for first filter paint
+2. test evidence with exact commands
+3. screenshots or short recordings for initial route load and rapid filter application
+4. risk notes covering URL state, sidebar loading, and grid behavior
+
+Recommended quality gates for the implementation PRs:
+
+1. `pnpm test`
+2. `pnpm typecheck`
+3. `pnpm lint`
+4. `pnpm build`
+5. `pnpm test:e2e` for any UI behavior change
+
+## 15. Definition of Done
+
+1. Trait names render from prefetched or hydrated data on first meaningful route paint.
+2. Sidebar usability is no longer blocked by listings-derived grid enrichment.
+3. URL-canonical filter state remains correct across refresh, share, and back/forward flows.
+4. Benchmark evidence shows improvement against the baseline targets in this document.
+5. All tests required by the relevant phase pass before merge.

--- a/src/app/collections/[address]/page.tsx
+++ b/src/app/collections/[address]/page.tsx
@@ -1,6 +1,10 @@
 import { Suspense } from "react";
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import type { Metadata } from "next";
 import { CollectionRouteContainer } from "@/features/collections/collection-route-container";
+import { getMarketplaceRuntimeConfig } from "@/lib/marketplace/config";
+import { prefetchTraitNamesSummary } from "@/lib/marketplace/trait-summary-prefetch";
+import { makeQueryClient } from "@/lib/marketplace/query-client";
 import { buildMarketplacePageMetadata } from "@/lib/seo/metadata";
 
 type CollectionPageProps = {
@@ -14,12 +18,23 @@ export default async function CollectionPage({
 }: CollectionPageProps) {
   const { address } = await params;
   const { cursor } = await searchParams;
+  const queryClient = makeQueryClient();
+  const selectedCollection = getMarketplaceRuntimeConfig().collections.find(
+    (collection) => collection.address === address,
+  );
+
+  await prefetchTraitNamesSummary(queryClient, {
+    address,
+    projectId: selectedCollection?.projectId,
+  });
 
   return (
     <main className="flex min-h-screen w-full items-start px-4 pb-6 sm:px-6 lg:px-8">
-      <Suspense>
-        <CollectionRouteContainer address={address} cursor={cursor ?? null} />
-      </Suspense>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Suspense>
+          <CollectionRouteContainer address={address} cursor={cursor ?? null} />
+        </Suspense>
+      </HydrationBoundary>
     </main>
   );
 }

--- a/src/features/collections/collection-route-container-url-sync.test.tsx
+++ b/src/features/collections/collection-route-container-url-sync.test.tsx
@@ -1,17 +1,19 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CollectionRouteContainer } from "@/features/collections/collection-route-container";
 import type { ActiveFilters } from "@/lib/marketplace/traits";
 
 const {
   mockCollectionRouteView,
   mockPush,
+  mockReplace,
   mockSearchParams,
   mockPathname,
 } = vi.hoisted(() => ({
   mockCollectionRouteView: vi.fn(),
   mockPush: vi.fn(),
+  mockReplace: vi.fn(),
   mockSearchParams: new URLSearchParams("cursor=page-2&foo=bar&trait=Eyes:Big&sort=price-asc"),
   mockPathname: "/collections/0xabc",
 }));
@@ -19,6 +21,7 @@ const {
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
+    replace: mockReplace,
   }),
   usePathname: () => mockPathname,
   useSearchParams: () => mockSearchParams,
@@ -81,7 +84,13 @@ vi.mock("@/features/collections/collection-route-view", () => ({
 }));
 
 describe("collection route container url sync", () => {
-  it("parses_trait_filters_from_url_and_pushes_updated_query", async () => {
+  beforeEach(() => {
+    mockCollectionRouteView.mockClear();
+    mockPush.mockClear();
+    mockReplace.mockClear();
+  });
+
+  it("parses_trait_filters_from_url_and_replaces_updated_query", async () => {
     const user = userEvent.setup();
 
     render(<CollectionRouteContainer address="0xabc" cursor={null} />);
@@ -92,19 +101,19 @@ describe("collection route container url sync", () => {
 
     await user.click(screen.getByRole("button", { name: /apply-filters/i }));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(mockReplace).toHaveBeenCalledWith(
       "/collections/0xabc?foo=bar&trait=Background%3ABlue",
     );
   });
 
-  it("pushes_updated_sort_to_url_and_resets_cursor", async () => {
+  it("replaces_updated_sort_in_url_and_resets_cursor", async () => {
     const user = userEvent.setup();
 
     render(<CollectionRouteContainer address="0xabc" cursor={null} />);
 
     await user.click(screen.getByRole("button", { name: /sort-power-desc/i }));
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(mockReplace).toHaveBeenCalledWith(
       "/collections/0xabc?foo=bar&trait=Eyes%3ABig&sort=power-desc",
     );
   });
@@ -131,8 +140,19 @@ describe("collection route container url sync", () => {
     await user.click(screen.getByRole("button", { name: /apply-filters/i }));
     await user.click(screen.getByRole("button", { name: /sort-power-desc/i }));
 
-    expect(mockPush).toHaveBeenLastCalledWith(
+    expect(mockReplace).toHaveBeenLastCalledWith(
       "/collections/0xabc?foo=bar&trait=Background%3ABlue&sort=power-desc",
     );
+  });
+
+  it("does_not_push_history_entries_for_in_page_discovery_changes", async () => {
+    const user = userEvent.setup();
+
+    render(<CollectionRouteContainer address="0xabc" cursor={null} />);
+
+    await user.click(screen.getByRole("button", { name: /apply-filters/i }));
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/collections/collection-route-container.tsx
+++ b/src/features/collections/collection-route-container.tsx
@@ -119,7 +119,7 @@ export function CollectionRouteContainer({
 
     dispatchOptimisticDiscoveryState({ type: "APPLY", state: clonedState });
     startTransition(() => {
-      router.push(query ? `${pathname}?${query}` : pathname);
+      router.replace(query ? `${pathname}?${query}` : pathname);
     });
   }, [pathname, router, searchParamsKey]);
 

--- a/src/features/collections/collection-route-view.tsx
+++ b/src/features/collections/collection-route-view.tsx
@@ -18,7 +18,11 @@ import {
   type SeedCollection,
   getMarketplaceRuntimeConfig,
 } from "@/lib/marketplace/config";
-import { type ActiveFilters, type TraitSelection } from "@/lib/marketplace/traits";
+import {
+  flattenExactActiveFilters,
+  type ActiveFilters,
+  type TraitSelection,
+} from "@/lib/marketplace/traits";
 import dynamic from "next/dynamic";
 
 const CollectionMarketPanel = dynamic(
@@ -198,13 +202,8 @@ export function CollectionRouteView({
 
   const otherTraitFilters = useMemo(() => {
     if (!openTraitName) return undefined;
-    const result: TraitSelection[] = [];
-    for (const [name, values] of Object.entries(resolvedActiveFilters)) {
-      if (name === openTraitName) continue;
-      for (const value of values) {
-        result.push({ name, value });
-      }
-    }
+    const result: TraitSelection[] = flattenExactActiveFilters(resolvedActiveFilters)
+      .filter((entry) => entry.name !== openTraitName);
     return result.length > 0 ? result : undefined;
   }, [openTraitName, resolvedActiveFilters]);
 

--- a/src/features/collections/collection-token-grid.test.tsx
+++ b/src/features/collections/collection-token-grid.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CollectionTokenGrid } from "@/features/collections/collection-token-grid";
 import { _resetConfigCache } from "@/lib/marketplace/config";
+import { encodeRangeFilterValue } from "@/lib/marketplace/traits";
 import type { ActiveFilters } from "@/lib/marketplace/traits";
 
 const { mockUseCollectionTokensQuery, mockUseCollectionListingsQuery } = vi.hoisted(() => ({
@@ -405,6 +406,54 @@ describe("collection token grid", () => {
     expect(mockUseCollectionTokensQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         attributeFilters: { Background: ["Blue"] },
+      }),
+    );
+  });
+
+  it("range_filters_stay_client_side_and_do_not_forward_exact_attribute_filters", async () => {
+    const filters: ActiveFilters = { Level: new Set([encodeRangeFilterValue(10, 20)]) };
+    mockUseCollectionTokensQuery.mockReturnValue({
+      data: {
+        page: {
+          tokens: [
+            token("1", {
+              metadata: {
+                name: "Token #1",
+                attributes: [{ trait_type: "Level", value: "15" }],
+              },
+            }),
+            token("2", {
+              metadata: {
+                name: "Token #2",
+                attributes: [{ trait_type: "Level", value: "25" }],
+              },
+            }),
+          ],
+          nextCursor: null,
+        },
+        error: null,
+      },
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <CollectionTokenGrid
+        activeFilters={filters}
+        address="0xabc"
+        projectId="project-a"
+      />,
+    );
+
+    expect(await screen.findByText("Token #1")).toBeVisible();
+    expect(screen.queryByText("Token #2")).toBeNull();
+    expect(mockUseCollectionTokensQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributeFilters: undefined,
       }),
     );
   });
@@ -835,7 +884,23 @@ describe("collection token grid", () => {
 
     mockUseCollectionTokensQuery.mockImplementation((options) => {
       const hasBlue = options?.attributeFilters?.Background?.includes("Blue");
-      const tokens = hasBlue ? [token("10")] : [token("20")];
+      const tokens = hasBlue
+        ? [
+          token("10", {
+            metadata: {
+              name: "Token #10",
+              attributes: [{ trait_type: "Background", value: "Blue" }],
+            },
+          }),
+        ]
+        : [
+          token("20", {
+            metadata: {
+              name: "Token #20",
+              attributes: [{ trait_type: "Background", value: "Red" }],
+            },
+          }),
+        ];
       return {
         data: { page: { tokens, nextCursor: null }, error: null },
         isLoading: false,

--- a/src/features/collections/collection-token-grid.test.tsx
+++ b/src/features/collections/collection-token-grid.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CollectionTokenGrid } from "@/features/collections/collection-token-grid";
@@ -181,7 +181,8 @@ describe("collection token grid", () => {
       />,
     );
 
-    expect(mockUseCollectionTokensQuery).toHaveBeenCalledWith(
+    expect(mockUseCollectionTokensQuery).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         address: "0xabc",
         project: "project-a",
@@ -189,6 +190,56 @@ describe("collection token grid", () => {
         tokenIds: ["7", "9"],
       }),
     );
+  });
+
+  it("defers_listed_token_enrichment_until_after_initial_render", async () => {
+    mockUseCollectionTokensQuery.mockReturnValue({
+      data: { page: { tokens: [token("1")], nextCursor: null }, error: null },
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+    mockUseCollectionListingsQuery.mockReturnValue(
+      successListingsResult([
+        { id: 101, tokenId: "7", price: 25, currency: "0xfee", quantity: 1 },
+      ]),
+    );
+
+    render(<CollectionTokenGrid address="0xabc" projectId="project-a" />);
+
+    expect(mockUseCollectionTokensQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        address: "0xabc",
+        project: "project-a",
+        tokenIds: undefined,
+      }),
+    );
+    expect(mockUseCollectionTokensQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        address: "0xabc",
+        project: "project-a",
+        tokenIds: expect.arrayContaining(["7", "0x7"]),
+      }),
+      expect.objectContaining({ enabled: false }),
+    );
+
+    await screen.findByText("Token #1");
+
+    await waitFor(() => {
+      expect(mockUseCollectionTokensQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          address: "0xabc",
+          project: "project-a",
+          tokenIds: expect.arrayContaining(["7", "0x7"]),
+        }),
+        expect.objectContaining({ enabled: true }),
+      );
+    });
   });
 
   it("token_grid_uses_image_fallback_when_missing", async () => {

--- a/src/features/collections/collection-token-grid.tsx
+++ b/src/features/collections/collection-token-grid.tsx
@@ -322,6 +322,7 @@ export function CollectionTokenGrid({
   const showInlineResources = collectionFilterConfig.showInlineResources === true;
   const tokenCardConfig = collectionFilterConfig.tokenCard;
   const [gridMode, setGridMode] = useState<GridLayoutMode>("compact");
+  const [armedListedTokenEnrichmentScopeKey, setArmedListedTokenEnrichmentScopeKey] = useState("");
   const tokenIdsKey = useMemo(() => tokenIds?.join(",") ?? "", [tokenIds]);
   const activeFiltersKey = useMemo(
     () =>
@@ -341,6 +342,10 @@ export function CollectionTokenGrid({
           )
         : undefined,
     [activeFilters],
+  );
+  const listedTokenEnrichmentScopeKey = useMemo(
+    () => [address, projectId ?? "", tokenIdsKey, activeFiltersKey].join("::"),
+    [activeFiltersKey, address, projectId, tokenIdsKey],
   );
   const [pagination, dispatch] = useReducer(gridPaginationReducer, {
     cursor: undefined,
@@ -372,6 +377,16 @@ export function CollectionTokenGrid({
   useEffect(() => {
     dispatch({ type: "RESET" });
   }, [address, projectId, limit, tokenIdsKey, activeFiltersKey]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setArmedListedTokenEnrichmentScopeKey(listedTokenEnrichmentScopeKey);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [listedTokenEnrichmentScopeKey]);
 
   useEffect(() => {
     if (!tokenQuery.isSuccess) return;
@@ -406,7 +421,12 @@ export function CollectionTokenGrid({
       fetchImages: true,
       attributeFilters,
     },
-    { enabled: listedQueryTokenIds.length > 0 },
+    {
+      enabled:
+        armedListedTokenEnrichmentScopeKey === listedTokenEnrichmentScopeKey
+        && !tokenIds?.length
+        && listedQueryTokenIds.length > 0,
+    },
   );
 
   const nextCursor = tokenQuery.data?.page?.nextCursor ?? null;

--- a/src/features/collections/collection-token-grid.tsx
+++ b/src/features/collections/collection-token-grid.tsx
@@ -30,8 +30,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { getCollectionFilterConfig } from "@/lib/marketplace/collection-filter-config";
-import type { ActiveFilters } from "@/lib/marketplace/traits";
-import { numericTraitValueByName } from "@/lib/marketplace/traits";
+import {
+  exactAttributeFiltersFromActiveFilters,
+  filterTokensByActiveFilters,
+  numericTraitValueByName,
+  type ActiveFilters,
+} from "@/lib/marketplace/traits";
 import { COLLECTION_LISTING_SAMPLE_LIMIT } from "@/lib/marketplace/query-limits";
 import { expandTokenIdQueryVariants } from "@/lib/marketplace/token-id";
 import { realmResourceCount, realmResources } from "@/lib/marketplace/token-attributes";
@@ -63,6 +67,7 @@ const GRID_CLASSES_BY_DENSITY: Record<GridDensityMode, string> = {
   compact: "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4",
   dense: "grid-cols-2 sm:grid-cols-3 lg:grid-cols-6",
 };
+const EMPTY_ACTIVE_FILTERS: ActiveFilters = {};
 
 function dedupeTokens(tokens: NormalizedToken[]) {
   const unique = new Map<string, NormalizedToken>();
@@ -335,12 +340,7 @@ export function CollectionTokenGrid({
     [activeFilters],
   );
   const attributeFilters = useMemo(
-    () =>
-      activeFilters && Object.keys(activeFilters).length > 0
-        ? Object.fromEntries(
-            Object.entries(activeFilters).map(([k, v]) => [k, Array.from(v)]),
-          )
-        : undefined,
+    () => exactAttributeFiltersFromActiveFilters(activeFilters),
     [activeFilters],
   );
   const listedTokenEnrichmentScopeKey = useMemo(
@@ -439,12 +439,16 @@ export function CollectionTokenGrid({
     if (!listedTokens?.length) return pagination.tokens;
     return dedupeTokens([...pagination.tokens, ...listedTokens]);
   }, [pagination.tokens, listedTokensQuery.data?.page?.tokens]);
+  const filteredVisibleTokens = useMemo(
+    () => filterTokensByActiveFilters(visibleTokens, activeFilters ?? EMPTY_ACTIVE_FILTERS),
+    [activeFilters, visibleTokens],
+  );
   const displayTokens = useMemo(
     () =>
       isAdventurersCollection
-        ? visibleTokens.filter(isAliveAdventurer)
-        : visibleTokens,
-    [isAdventurersCollection, visibleTokens],
+        ? filteredVisibleTokens.filter(isAliveAdventurer)
+        : filteredVisibleTokens,
+    [filteredVisibleTokens, isAdventurersCollection],
   );
   const visibleTokensSignature = useMemo(
     () => tokenSignature(displayTokens),

--- a/src/features/collections/filters/range-slider-filter.tsx
+++ b/src/features/collections/filters/range-slider-filter.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { Slider } from "@/components/ui/slider";
-import type { PrecomputedFilterProperty } from "@/lib/marketplace/traits";
+import {
+  decodeRangeFilterValue,
+  encodeRangeFilterValue,
+  type PrecomputedFilterProperty,
+} from "@/lib/marketplace/traits";
 
 type RangeSliderFilterProps = {
   activeValues?: Set<string>;
@@ -40,6 +44,16 @@ function selectedBounds(
   min: number,
   max: number,
 ) {
+  const rangeFilter = Array.from(activeValues ?? [])
+    .map((value) => decodeRangeFilterValue(value))
+    .find((value): value is NonNullable<typeof value> => value !== null);
+  if (rangeFilter) {
+    return [
+      Math.max(min, rangeFilter.min),
+      Math.min(max, rangeFilter.max),
+    ] as const;
+  }
+
   const selected = numericValues
     .filter((item) => activeValues?.has(item.rawValue) ?? false)
     .map((item) => item.numericValue);
@@ -88,11 +102,12 @@ export function RangeSliderFilter({
         onValueChange={(nextValue) => {
           const start = Math.min(nextValue[0] ?? min, nextValue[1] ?? max);
           const end = Math.max(nextValue[0] ?? min, nextValue[1] ?? max);
-          onChange(
-            numericValues
-              .filter((item) => item.numericValue >= start && item.numericValue <= end)
-              .map((item) => item.rawValue),
-          );
+          if (start <= min && end >= max) {
+            onChange([]);
+            return;
+          }
+
+          onChange([encodeRangeFilterValue(start, end)]);
         }}
       />
       <div className="flex items-center justify-between text-xs text-muted-foreground">

--- a/src/features/collections/trait-filter-sidebar.test.tsx
+++ b/src/features/collections/trait-filter-sidebar.test.tsx
@@ -14,11 +14,23 @@ vi.mock("@/lib/marketplace/collection-filter-config", () => ({
 }));
 
 vi.mock("@/components/ui/slider", () => ({
-  Slider: ({ value }: { value?: number[] }) => (
+  Slider: ({
+    value,
+    onValueChange,
+  }: {
+    value?: number[];
+    onValueChange?: (nextValue: number[]) => void;
+  }) => (
     <div data-testid="mock-slider">
       {(value ?? [0]).map((entry, index) => (
         <div key={`${entry}-${index}`} role="slider" aria-valuenow={entry} />
       ))}
+      <button type="button" aria-label="apply slider range" onClick={() => onValueChange?.([2, 3])}>
+        set-slider-range
+      </button>
+      <button type="button" aria-label="reset slider range" onClick={() => onValueChange?.([1, 3])}>
+        reset-slider-range
+      </button>
     </div>
   ),
 }));
@@ -448,6 +460,33 @@ describe("trait filter sidebar", () => {
 
     expect(screen.queryByRole("searchbox", { name: /search level/i })).toBeNull();
     expect(screen.getAllByRole("slider")).toHaveLength(2);
+  });
+
+  it("range_filter_emits_single_canonical_range_value", async () => {
+    mockGetCollectionFilterConfig.mockReturnValue({
+      hiddenTraits: [],
+      overrides: {
+        Level: { type: "range", min: 1, max: 3 },
+      },
+    });
+    const onActiveFiltersChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SidebarWrapper
+        collectionAddress="0xbeast"
+        traitNames={[traitName("Level")]}
+        traitValues={[traitValue("1"), traitValue("2"), traitValue("3")]}
+        initialOpenTraitName="Level"
+        onActiveFiltersChange={onActiveFiltersChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /apply slider range/i }));
+
+    expect(onActiveFiltersChange).toHaveBeenCalledWith({
+      Level: new Set(["__range__:2:3"]),
+    });
   });
 
   it("renders_pills_filter_with_alpha_sort_hidden_counts_and_hidden_search", () => {

--- a/src/lib/marketplace/hooks.ts
+++ b/src/lib/marketplace/hooks.ts
@@ -25,7 +25,8 @@ import {
 } from "@/lib/marketplace/token-id";
 import { normalizeMarketplaceAddress } from "@/lib/marketplace/address";
 import type { TraitSelection } from "@/lib/marketplace/traits";
-import { aggregateTraitSummaryPages, aggregateTraitValuePages } from "@/lib/marketplace/traits";
+import { aggregateTraitValuePages } from "@/lib/marketplace/traits";
+import { traitNamesSummaryQueryOptions } from "@/lib/marketplace/trait-summary-query";
 
 function hasUsableToken(data: TokenDetails | null | undefined): data is TokenDetails {
   return data !== null && data !== undefined && data.token !== null && data.token !== undefined;
@@ -255,17 +256,7 @@ export function useTraitNamesSummaryQuery(options: {
   projectId?: string;
 }) {
   return useQuery({
-    queryKey: ["trait-names-summary", options.address, options.projectId] as const,
-    queryFn: async () => {
-      const { fetchTraitNamesSummary } = await import(
-        "@cartridge/arcade/marketplace"
-      );
-      const result = await fetchTraitNamesSummary({
-        address: options.address,
-        defaultProjectId: options.projectId,
-      });
-      return aggregateTraitSummaryPages(result.pages);
-    },
+    ...traitNamesSummaryQueryOptions(options),
     enabled: !!options.address,
   });
 }

--- a/src/lib/marketplace/query-client.ts
+++ b/src/lib/marketplace/query-client.ts
@@ -1,5 +1,3 @@
-"use client";
-
 import { QueryClient } from "@tanstack/react-query";
 
 export function makeQueryClient() {

--- a/src/lib/marketplace/trait-summary-prefetch.test.ts
+++ b/src/lib/marketplace/trait-summary-prefetch.test.ts
@@ -1,0 +1,51 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+describe("trait summary prefetch", () => {
+  it("prefetches_summary_into_the_expected_query_cache_key", async () => {
+    const mockFetchTraitNamesSummary = vi.fn().mockResolvedValue({
+      pages: [
+        {
+          projectId: "project-a",
+          traits: [
+            { traitName: "Background", valueCount: 2 },
+            { traitName: "Eyes", valueCount: 3 },
+          ],
+        },
+      ],
+      errors: [],
+    });
+
+    vi.doMock("@cartridge/arcade/marketplace", () => ({
+      fetchTraitNamesSummary: mockFetchTraitNamesSummary,
+    }));
+
+    const {
+      traitNamesSummaryQueryKey,
+    } = await import("@/lib/marketplace/trait-summary-query");
+    const { prefetchTraitNamesSummary } = await import(
+      "@/lib/marketplace/trait-summary-prefetch"
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    await prefetchTraitNamesSummary(queryClient, {
+      address: "0xabc",
+      projectId: "project-a",
+    });
+
+    expect(mockFetchTraitNamesSummary).toHaveBeenCalledWith({
+      address: "0xabc",
+      defaultProjectId: "project-a",
+    });
+    expect(
+      queryClient.getQueryData(
+        traitNamesSummaryQueryKey({ address: "0xabc", projectId: "project-a" }),
+      ),
+    ).toEqual([
+      { traitName: "Background", valueCount: 2 },
+      { traitName: "Eyes", valueCount: 3 },
+    ]);
+  });
+});

--- a/src/lib/marketplace/trait-summary-prefetch.ts
+++ b/src/lib/marketplace/trait-summary-prefetch.ts
@@ -1,0 +1,34 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { unstable_cache } from "next/cache";
+import { cache } from "react";
+import {
+  TRAIT_SUMMARY_STALE_TIME_MS,
+  fetchTraitNamesSummaryAggregate,
+  traitNamesSummaryQueryKey,
+  type TraitNamesSummaryQueryInput,
+} from "@/lib/marketplace/trait-summary-query";
+
+const fetchCachedTraitNamesSummary = unstable_cache(
+  async (address: string, projectId?: string) =>
+    fetchTraitNamesSummaryAggregate({ address, projectId }),
+  ["trait-names-summary"],
+  {
+    revalidate: TRAIT_SUMMARY_STALE_TIME_MS / 1000,
+  },
+);
+
+const fetchServerTraitNamesSummary = cache(
+  async (address: string, projectId?: string) =>
+    fetchCachedTraitNamesSummary(address, projectId),
+);
+
+export async function prefetchTraitNamesSummary(
+  queryClient: QueryClient,
+  options: TraitNamesSummaryQueryInput,
+) {
+  await queryClient.prefetchQuery({
+    queryKey: traitNamesSummaryQueryKey(options),
+    queryFn: () => fetchServerTraitNamesSummary(options.address, options.projectId),
+    staleTime: TRAIT_SUMMARY_STALE_TIME_MS,
+  });
+}

--- a/src/lib/marketplace/trait-summary-query.ts
+++ b/src/lib/marketplace/trait-summary-query.ts
@@ -1,0 +1,36 @@
+import { queryOptions } from "@tanstack/react-query";
+import {
+  aggregateTraitSummaryPages,
+  type TraitNameSummary,
+} from "@/lib/marketplace/traits";
+
+export const TRAIT_SUMMARY_STALE_TIME_MS = 60_000;
+
+export type TraitNamesSummaryQueryInput = {
+  address: string;
+  projectId?: string;
+};
+
+export function traitNamesSummaryQueryKey(options: TraitNamesSummaryQueryInput) {
+  return ["trait-names-summary", options.address, options.projectId] as const;
+}
+
+export async function fetchTraitNamesSummaryAggregate(
+  options: TraitNamesSummaryQueryInput,
+): Promise<TraitNameSummary[]> {
+  const { fetchTraitNamesSummary } = await import("@cartridge/arcade/marketplace");
+  const result = await fetchTraitNamesSummary({
+    address: options.address,
+    defaultProjectId: options.projectId,
+  });
+
+  return aggregateTraitSummaryPages(result.pages);
+}
+
+export function traitNamesSummaryQueryOptions(options: TraitNamesSummaryQueryInput) {
+  return queryOptions({
+    queryKey: traitNamesSummaryQueryKey(options),
+    queryFn: () => fetchTraitNamesSummaryAggregate(options),
+    staleTime: TRAIT_SUMMARY_STALE_TIME_MS,
+  });
+}

--- a/src/lib/marketplace/traits.test.ts
+++ b/src/lib/marketplace/traits.test.ts
@@ -5,6 +5,7 @@ import {
   aggregateTraitSummaryPages,
   computeAvailableFilters,
   computePrecomputedFilters,
+  encodeRangeFilterValue,
   fetchFilteredTraitValues,
   fetchTraitNamesSummary,
   filterTokensByActiveFilters,
@@ -128,6 +129,22 @@ describe("marketplace trait utilities", () => {
     expect(Array.from(roundTripped.Eyes).sort()).toEqual(["Big"]);
   });
 
+  it("range_filters_round_trip_with_single_url_entry", () => {
+    const filters = {
+      Level: new Set([encodeRangeFilterValue(10, 20)]),
+    };
+
+    const params = activeFiltersToSearchParams(filters);
+    const roundTripped = activeFiltersFromSearchParams(params);
+
+    expect(params.getAll("trait")).toEqual([
+      "Level:__range__:10:20",
+    ]);
+    expect(Array.from(roundTripped.Level)).toEqual([
+      "__range__:10:20",
+    ]);
+  });
+
   it("trait_names_summary_calls_fetcher_and_aggregates", async () => {
     const fetcher = vi.fn(async () => ({
       pages: [
@@ -194,6 +211,28 @@ describe("marketplace trait utilities", () => {
     expect(byBatch.map((item) => item.token_id)).toEqual(
       bySingle.map((item) => item.token_id),
     );
+  });
+
+  it("token_matches_numeric_range_filters", () => {
+    const filters = { Level: new Set([encodeRangeFilterValue(10, 20)]) };
+    const tokens = [
+      {
+        token_id: "1",
+        metadata: {
+          attributes: [{ trait_type: "Level", value: "15" }],
+        },
+      },
+      {
+        token_id: "2",
+        metadata: {
+          attributes: [{ trait_type: "Level", value: "25" }],
+        },
+      },
+    ];
+
+    expect(tokenMatchesActiveFilters(tokens[0], filters)).toBe(true);
+    expect(tokenMatchesActiveFilters(tokens[1], filters)).toBe(false);
+    expect(filterTokensByActiveFilters(tokens, filters).map((item) => item.token_id)).toEqual(["1"]);
   });
 
   it("reads_trait_values_from_mixed_metadata_shapes", () => {

--- a/src/lib/marketplace/traits.ts
+++ b/src/lib/marketplace/traits.ts
@@ -74,9 +74,16 @@ export type PrecomputedFilterData = {
   properties: Record<string, PrecomputedFilterProperty[]>;
 };
 
+export type NumericRangeFilter = {
+  min: number;
+  max: number;
+};
+
 type TokenLike = {
   metadata?: unknown;
 };
+
+const RANGE_FILTER_PREFIX = "__range__:";
 
 function normalizeTraitValue(value: unknown) {
   if (value === null || value === undefined) {
@@ -84,6 +91,34 @@ function normalizeTraitValue(value: unknown) {
   }
 
   return String(value);
+}
+
+export function encodeRangeFilterValue(min: number, max: number) {
+  const lower = Math.min(min, max);
+  const upper = Math.max(min, max);
+  return `${RANGE_FILTER_PREFIX}${lower}:${upper}`;
+}
+
+export function decodeRangeFilterValue(value: string): NumericRangeFilter | null {
+  if (!value.startsWith(RANGE_FILTER_PREFIX)) {
+    return null;
+  }
+
+  const [rawMin, rawMax] = value.slice(RANGE_FILTER_PREFIX.length).split(":");
+  const min = Number(rawMin);
+  const max = Number(rawMax);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return null;
+  }
+
+  return {
+    min: Math.min(min, max),
+    max: Math.max(min, max),
+  };
+}
+
+export function isRangeFilterValue(value: string) {
+  return decodeRangeFilterValue(value) !== null;
 }
 
 export function aggregateTraitSummaryPages(pages: TraitNameSummaryPage[]) {
@@ -213,6 +248,27 @@ export function flattenActiveFilters(activeFilters: ActiveFilters): TraitSelecti
   return entries;
 }
 
+export function flattenExactActiveFilters(activeFilters: ActiveFilters): TraitSelection[] {
+  return flattenActiveFilters(activeFilters).filter((entry) => !isRangeFilterValue(entry.value));
+}
+
+export function exactAttributeFiltersFromActiveFilters(activeFilters?: ActiveFilters) {
+  if (!activeFilters || Object.keys(activeFilters).length === 0) {
+    return undefined;
+  }
+
+  const filters = Object.fromEntries(
+    Object.entries(activeFilters)
+      .map(([traitName, values]) => [
+        traitName,
+        Array.from(values).filter((value) => !isRangeFilterValue(value)),
+      ])
+      .filter(([, values]) => values.length > 0),
+  );
+
+  return Object.keys(filters).length > 0 ? filters : undefined;
+}
+
 export function activeFiltersToSearchParams(activeFilters: ActiveFilters) {
   const params = new URLSearchParams();
   flattenActiveFilters(activeFilters).forEach((entry) => {
@@ -304,6 +360,20 @@ export function tokenMatchesActiveFilters(
   return entries.every(([traitName, acceptedValues]) => {
     if (acceptedValues.size === 0) {
       return true;
+    }
+
+    const rangeFilters = Array.from(acceptedValues)
+      .map((value) => decodeRangeFilterValue(value))
+      .filter((value): value is NumericRangeFilter => value !== null);
+    if (rangeFilters.length > 0) {
+      const actualNumericValue = numericTraitValueByName(token.metadata, traitName);
+      if (actualNumericValue === null) {
+        return false;
+      }
+
+      return rangeFilters.some(
+        (range) => actualNumericValue >= range.min && actualNumericValue <= range.max,
+      );
     }
 
     const actual = traitValueByName(token.metadata, traitName);

--- a/tests/e2e/purchase-funnel.spec.ts
+++ b/tests/e2e/purchase-funnel.spec.ts
@@ -87,7 +87,9 @@ test.describe("purchase funnel skeleton", () => {
       "Portfolio holdings view did not initialize in this environment.",
     );
 
-    await expect(page.getByText("0x1")).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: /wallet address/i }),
+    ).toHaveValue("0x1");
 
     const emptyStateVisible =
       (await page.getByText(/no items found for this wallet/i).count()) > 0;


### PR DESCRIPTION
Adds the collection filter performance TDD PRD and implements the first route-side optimizations from it. The collection route now server-prefetches trait summaries into React Query hydration, uses a shared summary query/cache definition, and makes the query client server-safe for that path. In-page collection filter and sort changes now use history-neutral URL replacement, and listed-token enrichment is deferred until after initial render to keep it off the first filter-paint path. Regression coverage was added for the prefetch cache key, replace-based URL syncing, and deferred enrichment behavior, and the branch passes pnpm test, pnpm typecheck, pnpm lint, and pnpm build.